### PR TITLE
Add release candidate support

### DIFF
--- a/.github/workflows/build-pre-release.yml
+++ b/.github/workflows/build-pre-release.yml
@@ -133,16 +133,14 @@ jobs:
         id: get_version
         shell: pwsh
         run: |
-          $tags = git tag
-          if ($tags -ne $null -and $tags.Count -gt 0) {
-            $latestTag = (git describe --tags --abbrev=0 2>$null) -replace '^v', ''
-            if (-not $latestTag) {
-              $latestTag = "0.0.0"
-            }
+          $allTags = git tag
+          $stableTags = $allTags | Where-Object { $_ -notmatch '-rc\.\d+$' }
+          if ($stableTags -and $stableTags.Count -gt 0) {
+            $latestTag = ($stableTags | Sort-Object { [version]($_ -replace '^v','') } -Descending | Select-Object -First 1) -replace '^v',''
           } else {
-            $latestTag = "0.0.0"
+            $latestTag = '0.0.0'
           }
-          $latestTag = [string]$latestTag
+
           $versionParts = $latestTag.Split('.')
           $major = [int]$versionParts[0]
           $minor = [int]$versionParts[1]
@@ -153,10 +151,20 @@ jobs:
             "major" { $major++; $minor=0; $patch=0 }
             "minor" { $minor++; $patch=0 }
             "patch" { $patch++ }
-            default { $patch++ } 
+            default { $patch++ }
           }
 
-          $newVersion = "$major.$minor.$patch"
+          $baseVersion = "$major.$minor.$patch"
+
+          $rcTags = git tag --list "v$baseVersion-rc.*"
+          if ($rcTags) {
+            $maxRc = ($rcTags | ForEach-Object { ($_ -split '-rc\.')[1] -as [int] } | Measure-Object -Maximum).Maximum
+            $rc = $maxRc + 1
+          } else {
+            $rc = 1
+          }
+
+          $newVersion = "$baseVersion-rc.$rc"
           echo "new_version=$newVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
           echo "new_version=$newVersion" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -16,14 +16,15 @@ jobs:
       - name: Convert Pre-Release to Final
         run: |
           VERSION="${{ github.event.inputs.version }}"
+          API_URL="https://api.github.com/repos/${{ github.repository }}/releases"
           RELEASE_ID=$(curl -s \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/releases/tags/v$VERSION \
-            | jq -r '.id')
+            $API_URL \
+            | jq -r '[.[] | select(.tag_name | test("^v" + env.VERSION + "-rc\\.\\d+$"))] | sort_by(.tag_name) | last | .id')
 
           if [ "$RELEASE_ID" = "null" ] || [ -z "$RELEASE_ID" ]; then
-            echo "No release found for version $VERSION"
+            echo "No pre-release found for version $VERSION"
             exit 1
           fi
 
@@ -31,5 +32,5 @@ jobs:
             -X PATCH \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID \
-            -d '{"prerelease": false, "name": "Release v'"$VERSION"'", "make_latest": true}'
+            $API_URL/$RELEASE_ID \
+            -d '{"tag_name":"v'"$VERSION"'","prerelease":false,"name":"Release v'"$VERSION"'","make_latest":true}'

--- a/Backend/Utils/UpdateUtils.cs
+++ b/Backend/Utils/UpdateUtils.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using NuGet.Versioning;
 using Velopack;
 using Velopack.Sources;
 
@@ -130,17 +131,17 @@ namespace Segra.Backend.Utils
                 Log.Information("Getting release notes from GitHub API");
 
                 // Get current version
-                Version currentVersion;
+                SemanticVersion currentVersion;
                 if (UpdateManager.CurrentVersion != null)
                 {
-                    currentVersion = Version.Parse(UpdateManager.CurrentVersion.ToString());
+                    currentVersion = UpdateManager.CurrentVersion;
                 }
                 else
                 {
                     // Running in local development, uncomment the line bellow and comment out the return to test
-                    currentVersion = Version.Parse("0.6.6");
+                    currentVersion = SemanticVersion.Parse("0.6.6");
                     //Log.Error("Could not get current version");
-                    //return; 
+                    //return;
                 }
 
                 Log.Information($"Current version: {currentVersion}");
@@ -168,7 +169,7 @@ namespace Segra.Backend.Utils
 
                 // Filter and process releases
                 var releaseNotesList = new List<object>();
-                Version targetVersion = null;
+                SemanticVersion? targetVersion = null;
 
                 // Check if beta releases should be included
                 bool includeBeta = Models.Settings.Instance.ReceiveBetaUpdates;
@@ -188,7 +189,7 @@ namespace Segra.Backend.Utils
                         versionString = versionString.Substring(1);
                     }
 
-                    if (!Version.TryParse(versionString, out var releaseVersion))
+                    if (!SemanticVersion.TryParse(versionString, out var releaseVersion))
                     {
                         Log.Warning($"Could not parse version from tag: {release.TagName}");
                         continue;
@@ -197,7 +198,7 @@ namespace Segra.Backend.Utils
                     // Skip if this version is not what we're looking for based on includeOnlyRecentUpdate
                     if (targetVersion != null)
                     {
-                        if (releaseVersion <= currentVersion)
+                        if (releaseVersion.CompareTo(currentVersion) <= 0)
                         {
                             continue;
                         }


### PR DESCRIPTION
## Summary
- support parsing prerelease tags when generating release notes
- calculate next release candidate version in workflow
- finalize release by converting highest matching rc tag to stable

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_683f706f78fc8327a6af4840ae8dd1cf