### PR TITLE
fix: set CQ Level input width to full

### DIFF
--- a/Frontend/src/Pages/settings.tsx
+++ b/Frontend/src/Pages/settings.tsx
@@ -841,7 +841,7 @@ export default function Settings() {
                 onChange={handleChange}
                 min="0"
                 max="30"
-                className="input input-bordered bg-base-200"
+                className="input input-bordered bg-base-200 w-full"
               />
             </div>
           )}


### PR DESCRIPTION
CQ Level field width was not matching the other dropdown fields