### PR TITLE
Fix: Friendlier names for Steelseries sonar in/outputs

### DIFF
--- a/Backend/Utils/AudioDeviceUtils.cs
+++ b/Backend/Utils/AudioDeviceUtils.cs
@@ -15,6 +15,14 @@ namespace Segra.Backend.Utils
             {
                 return friendlyName;
             }
+            else if (friendlyName.Contains("SteelSeries Sonar"))
+            {
+                int index = friendlyName.IndexOf("(");
+                if (index > 0)
+                {
+                    return friendlyName.Substring(0, index).Trim();
+                }
+            }
 
             // Looks for patterns like "Microphone (2- Shure MV7)" or "Speakers (Sound BlasterX AE-5 Plus)" or "Stereo Mix (Realtek(R) Audio)"
             // Extract the main part of the device name, handling cases with nested parentheses


### PR DESCRIPTION
Fix SteelSeries sonar audio devices to use friendlier names. As it is right now they are all listed as `SteelSeries Sonar Virtual Audio device`. This fix instead makes them listed as `SteelSeries Sonar - Gaming`, `SteelSeries Sonar - Chat`, etc.

Right now:
<img width="974" height="234" alt="Segra_L35AoIIjae" src="https://github.com/user-attachments/assets/34e74807-1b8e-47b2-9929-e3eb07715170" />

With this fix:
<img width="971" height="231" alt="image" src="https://github.com/user-attachments/assets/e415e544-ec03-43f3-87c4-3a021fa56b5e" />
