### PR TITLE
Use RNNoise for input noise suppression

### DIFF
--- a/Backend/Recorder/OBSService.cs
+++ b/Backend/Recorder/OBSService.cs
@@ -819,17 +819,14 @@ namespace Segra.Backend.Recorder
                         {
                             try
                             {
-                                var noiseGate = new Source("noise_gate_filter", $"{sourceName}_NoiseGate");
-                                noiseGate.Update(s =>
+                                var noiseSuppression = new Source("noise_suppress_filter", $"{sourceName}_NoiseSuppression");
+                                noiseSuppression.Update(s =>
                                 {
-                                    s.Set("close_threshold", -48.0);
-                                    s.Set("open_threshold", -42.0);
-                                    s.Set("attack_time", 25L);
-                                    s.Set("hold_time", 200L);
-                                    s.Set("release_time", 150L);
+                                    s.Set("method", "rnnoise");
+                                    s.Set("suppress_level", -30L);
                                 });
-                                micSource.AddFilter(noiseGate);
-                                Log.Information($"Added noise suppression filter to {sourceName}");
+                                micSource.AddFilter(noiseSuppression);
+                                Log.Information($"Added RNNoise noise suppression filter to {sourceName}");
                             }
                             catch (Exception ex)
                             {


### PR DESCRIPTION
Replace the “Noise Suppression” noise gate with OBS's built-in RNNoise suppression filter. The previous implementation used `noise_gate_filter`, which only mutes input below a threshold. That doesn't work well especially if the considered action is noise suppresion, especially for keyboard/mouse noise. OBS's noise_suppress_filter is a better fit for the current setting.