### PR TITLE
Use culture-invariant settings key lookup

### DIFF
--- a/Backend/Core/SettingsService.cs
+++ b/Backend/Core/SettingsService.cs
@@ -80,7 +80,7 @@ namespace Segra.Backend.Core
                         {
                             if (property.Value.ValueKind == JsonValueKind.Array)
                             {
-                                var propertyName = char.ToUpper(property.Name[0]) + property.Name.Substring(1);
+                                var propertyName = char.ToUpperInvariant(property.Name[0]) + property.Name.Substring(1);
                                 var targetProperty = typeof(Settings).GetProperty(
                                     propertyName,
                                     System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
@@ -125,7 +125,7 @@ namespace Segra.Backend.Core
                             }
                             else
                             {
-                                var propertyName = char.ToUpper(property.Name[0]) + property.Name.Substring(1);
+                                var propertyName = char.ToUpperInvariant(property.Name[0]) + property.Name.Substring(1);
                                 var targetProperty = typeof(Settings).GetProperty(
                                     propertyName,
                                     System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);


### PR DESCRIPTION
Fixes settings loading on systems where the current culture changes uppercase conversion behavior, such as Turkish. settings loader maps JSON keys like inputDevices to C# property names like InputDevices by uppercasing the first character. 

Using culture-aware char.ToUpper() can produce culture-specific characters, causing reflection lookup to fail for some settings.

This switches the lookup to char.ToUpperInvariant() so settings load consistently across locales. Basically a one-liner change. Came across this issue due to my device language.