### PR TITLE
Add Apex Legends OCR highlights

### DIFF
--- a/Backend/App/DiagnosticsService.cs
+++ b/Backend/App/DiagnosticsService.cs
@@ -440,7 +440,7 @@ namespace Segra.Backend.App
             Log.Information("--- Game detection ---");
             var s = Settings.Instance;
             Log.Information($"Custom game settings: {s.Games.Count} entries ({s.Games.Count(g => g.Record)} recording, {s.Games.Count(g => !g.Record)} blocked)");
-            Log.Information($"Game integrations: CS2={s.GameIntegrations.CounterStrike2.Enabled}, LoL={s.GameIntegrations.LeagueOfLegends.Enabled}, PUBG={s.GameIntegrations.Pubg.Enabled}, RocketLeague={s.GameIntegrations.RocketLeague.Enabled}");
+            Log.Information($"Game integrations: CS2={s.GameIntegrations.CounterStrike2.Enabled}, LoL={s.GameIntegrations.LeagueOfLegends.Enabled}, PUBG={s.GameIntegrations.Pubg.Enabled}, RocketLeague={s.GameIntegrations.RocketLeague.Enabled}, Apex={s.GameIntegrations.ApexLegends.Enabled}");
         }
 
         private static void LogAccountAndMisc()

--- a/Backend/Core/Models/Settings.cs
+++ b/Backend/Core/Models/Settings.cs
@@ -1437,6 +1437,9 @@ namespace Segra.Backend.Core.Models
         [JsonPropertyName("rocketLeague")]
         public GameIntegrationSettings RocketLeague { get; set; } = new GameIntegrationSettings(true);
 
+        [JsonPropertyName("apexLegends")]
+        public GameIntegrationSettings ApexLegends { get; set; } = new GameIntegrationSettings(true);
+
         [JsonPropertyName("dota2")]
         public GameIntegrationSettings Dota2 { get; set; } = new GameIntegrationSettings(true);
 

--- a/Backend/Core/SettingsService.cs
+++ b/Backend/Core/SettingsService.cs
@@ -396,6 +396,12 @@ namespace Segra.Backend.Core
                     current.RocketLeague.Enabled = updated.RocketLeague.Enabled;
                     hasChanges = true;
                 }
+                if (current.ApexLegends.Enabled != updated.ApexLegends.Enabled)
+                {
+                    Log.Information($"GameIntegrations.ApexLegends.Enabled changed from '{current.ApexLegends.Enabled}' to '{updated.ApexLegends.Enabled}'");
+                    current.ApexLegends.Enabled = updated.ApexLegends.Enabled;
+                    hasChanges = true;
+                }
                 if (current.Gta.Enabled != updated.Gta.Enabled)
                 {
                     Log.Information($"GameIntegrations.Gta.Enabled changed from '{current.Gta.Enabled}' to '{updated.Gta.Enabled}'");

--- a/Backend/Games/ApexLegends/ApexLegendsIntegration.cs
+++ b/Backend/Games/ApexLegends/ApexLegendsIntegration.cs
@@ -1,0 +1,25 @@
+using Segra.Backend.Core.Models;
+
+namespace Segra.Backend.Games.ApexLegends
+{
+    internal class ApexLegendsIntegration : OcrIntegration
+    {
+        protected override OcrConfig GetConfig() => new()
+        {
+            LogPrefix = "Apex",
+            CropRegion = new CropRegion(X: 0.00, Y: 0.10, Width: 1.00, Height: 0.75),
+            Threshold = 125,
+            PollIntervalMs = 300,
+            EventCooldown = TimeSpan.FromSeconds(8),
+            TimeCompensation = TimeSpan.FromSeconds(1.25),
+            Keywords =
+            [
+                new() { Text = "KNOCKED DOWN", BookmarkType = BookmarkType.Kill },
+                new() { Text = "SQUAD WIPE", BookmarkType = BookmarkType.Kill },
+                new() { Text = "ELIMINATED", BookmarkType = BookmarkType.Kill },
+                new() { Text = "ASSIST ELIMINATION", BookmarkType = BookmarkType.Assist },
+                new() { Text = "YOU ARE THE CHAMPION", BookmarkType = BookmarkType.Kill, CooldownGroup = "Victory" },
+            ],
+        };
+    }
+}

--- a/Backend/Games/GameIntegrationService.cs
+++ b/Backend/Games/GameIntegrationService.cs
@@ -9,6 +9,7 @@ using Segra.Backend.Games.CounterStrike2;
 using Segra.Backend.Games.LeagueOfLegends;
 using Segra.Backend.Games.RunescapeDragonwilds;
 #if WINDOWS
+using Segra.Backend.Games.ApexLegends;
 using Segra.Backend.Games.RocketLeague;
 using Segra.Backend.Games.GrandTheftAuto;
 #endif
@@ -26,6 +27,7 @@ namespace Segra.Backend.Games
         private const int MINECRAFT_IGDB_ID = 135400;
         private const int RUNESCAPE_DRAGONWILDS_IGDB_ID = 337712;
         private const int WAR_THUNDER_IGDB_ID = 2165;
+        private const int APEX_LEGENDS_IGDB_ID = 114795;
 
         private const int GTA_V_IGDB_ID = 1020;
         private const int FIVEM_IGDB_ID = 146553;
@@ -57,6 +59,11 @@ namespace Segra.Backend.Games
 #if WINDOWS
                 else if ((igdbId == ROCKET_LEAGUE_IGDB_ID || gameName?.Equals("Rocket League", StringComparison.OrdinalIgnoreCase) == true) && integrations.RocketLeague.Enabled)
                     _gameIntegration = new RocketLeagueIntegration();
+                else if ((igdbId == APEX_LEGENDS_IGDB_ID
+                          || gameName?.Equals("Apex Legends", StringComparison.OrdinalIgnoreCase) == true
+                          || exePath?.EndsWith("r5apex.exe", StringComparison.OrdinalIgnoreCase) == true
+                          || exePath?.EndsWith("r5apex_dx12.exe", StringComparison.OrdinalIgnoreCase) == true) && integrations.ApexLegends.Enabled)
+                    _gameIntegration = new ApexLegendsIntegration();
 #endif
                 else if ((igdbId == DOTA2_IGDB_ID || gameName?.Equals("Dota 2", StringComparison.OrdinalIgnoreCase) == true) && integrations.Dota2.Enabled)
                     _gameIntegration = new Dota2Integration();

--- a/Backend/Games/OcrIntegration.cs
+++ b/Backend/Games/OcrIntegration.cs
@@ -5,6 +5,8 @@ using System.Drawing.Imaging;
 using global::Windows.Media.Ocr;
 using Segra.Backend.Core.Models;
 using System.Runtime.InteropServices;
+using System.Globalization;
+using System.Text;
 using global::Windows.Graphics.Imaging;
 
 namespace Segra.Backend.Games
@@ -18,11 +20,12 @@ namespace Segra.Backend.Games
         private CancellationTokenSource? _cts;
         private readonly OcrEngine _ocrEngine;
         private readonly OcrConfig _config;
-        private readonly Dictionary<BookmarkType, DateTime> _lastEventTime;
+        private readonly Dictionary<string, DateTime> _lastEventTime;
         private readonly Dictionary<BookmarkType, PendingEvent> _pendingEvents = new();
 
         private readonly record struct PendingEvent(
             string Keyword,
+            string CooldownGroup,
             IReadOnlyList<string> ExcludeFragments,
             DateTime DetectedAtUtc,
             DateTime DetectedAtLocal);
@@ -46,6 +49,7 @@ namespace Segra.Backend.Games
             public required string Text { get; init; }
             public required BookmarkType BookmarkType { get; init; }
             public IReadOnlyList<string> ExcludeFragments { get; init; } = [];
+            public string? CooldownGroup { get; init; }
         }
 
         protected abstract OcrConfig GetConfig();
@@ -60,9 +64,9 @@ namespace Segra.Backend.Games
 
             // Initialize per-event-type cooldown tracking from configured keywords
             _lastEventTime = _config.Keywords
-                .Select(k => k.BookmarkType)
-                .Distinct()
-                .ToDictionary(bt => bt, _ => DateTime.MinValue);
+                .Select(GetCooldownGroup)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group, _ => DateTime.MinValue, StringComparer.OrdinalIgnoreCase);
         }
 
         public override Task Start()
@@ -214,7 +218,8 @@ namespace Segra.Backend.Games
                         continue;
 
                     var now = DateTime.UtcNow;
-                    if (now - _lastEventTime[keyword.BookmarkType] < _config.EventCooldown)
+                    var cooldownGroup = GetCooldownGroup(keyword);
+                    if (now - _lastEventTime[cooldownGroup] < _config.EventCooldown)
                         break;
 
                     if (keyword.ExcludeFragments.Count > 0)
@@ -227,14 +232,14 @@ namespace Segra.Backend.Games
                         if (!_pendingEvents.ContainsKey(keyword.BookmarkType))
                         {
                             _pendingEvents[keyword.BookmarkType] = new PendingEvent(
-                                keyword.Text, keyword.ExcludeFragments, now, DateTime.Now);
+                                keyword.Text, cooldownGroup, keyword.ExcludeFragments, now, DateTime.Now);
                             Log.Debug($"[{_config.LogPrefix}] Pending '{keyword.Text}' detection, waiting for confirmation");
                         }
                     }
                     else
                     {
                         // No exclude fragments — confirm immediately
-                        _lastEventTime[keyword.BookmarkType] = now;
+                        _lastEventTime[cooldownGroup] = now;
                         AddBookmark(keyword.BookmarkType);
                         Log.Information($"[{_config.LogPrefix}] Detected '{keyword.Text}' in OCR text -> {keyword.BookmarkType}");
                     }
@@ -268,35 +273,46 @@ namespace Segra.Backend.Games
         /// </summary>
         private static bool FuzzyContains(string text, string keyword)
         {
+            var normalizedKeyword = NormalizeOcrText(keyword);
+            var normalizedText = NormalizeOcrText(text);
+
             // Exact match first (fast path)
-            if (text.Contains(keyword, StringComparison.OrdinalIgnoreCase))
+            if (normalizedText.Contains(normalizedKeyword, StringComparison.OrdinalIgnoreCase))
                 return true;
 
             // Short keywords (<=5 chars): exact match only to avoid false positives
-            if (keyword.Length <= 5)
+            if (normalizedKeyword.Length <= 5)
                 return false;
 
-            var keywordLower = keyword.ToLowerInvariant();
-            int maxAllowed = keyword.Length / 4;
+            var keywordWords = SplitWords(normalizedKeyword);
+            var textWords = SplitWords(normalizedText);
+            var keywordLower = string.Join(' ', keywordWords).ToLowerInvariant();
+            var textWithSingleSpaces = string.Join(' ', textWords);
+            if (textWithSingleSpaces.Contains(keywordLower, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            var compactKeyword = string.Concat(keywordWords);
+            var compactText = string.Concat(textWords);
+            if (compactText.Contains(compactKeyword, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            int maxAllowed = normalizedKeyword.Length / 4;
 
             // OCR sometimes splits words (e.g. "DEMOL ION" for "DEMOLITION")
             // Try matching with spaces removed for single-word keywords
-            var keywordWords = keyword.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             if (keywordWords.Length == 1)
             {
-                var textNoSpaces = text.Replace(" ", "").ToLowerInvariant();
                 // Slide a character window over the spaceless text
                 int kwLen = keywordLower.Length;
-                for (int i = 0; i <= textNoSpaces.Length - kwLen; i++)
+                for (int i = 0; i <= compactText.Length - kwLen; i++)
                 {
-                    var window = textNoSpaces.Substring(i, kwLen);
-                    if (LevenshteinDistance(window, keywordLower) <= maxAllowed)
+                    var window = compactText.Substring(i, kwLen);
+                    if (LevenshteinDistance(window.ToLowerInvariant(), keywordLower) <= maxAllowed)
                         return true;
                 }
             }
 
             // Fuzzy: slide a window of keyword's word count over OCR words
-            var textWords = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             int windowSize = keywordWords.Length;
 
             if (textWords.Length < windowSize)
@@ -310,6 +326,29 @@ namespace Segra.Backend.Games
             }
 
             return false;
+        }
+
+        private static string[] SplitWords(string text)
+        {
+            return text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        private static string NormalizeOcrText(string text)
+        {
+            var builder = new StringBuilder(text.Length);
+            foreach (var c in text.Normalize(NormalizationForm.FormD))
+            {
+                var category = CharUnicodeInfo.GetUnicodeCategory(c);
+                if (category == UnicodeCategory.NonSpacingMark)
+                    continue;
+
+                if (char.IsLetterOrDigit(c))
+                    builder.Append(char.ToLowerInvariant(c == 'ı' ? 'i' : c));
+                else
+                    builder.Append(' ');
+            }
+
+            return builder.ToString().Normalize(NormalizationForm.FormC);
         }
 
         /// <summary>
@@ -364,14 +403,14 @@ namespace Segra.Backend.Games
                 if (now - pending.DetectedAtUtc >= _config.ExcludeCheckWindow)
                 {
                     // Another keyword (e.g. "+100") may have already fired for this type
-                    if (now - _lastEventTime[bookmarkType] < _config.EventCooldown)
+                    if (now - _lastEventTime[pending.CooldownGroup] < _config.EventCooldown)
                     {
                         Log.Debug($"[{_config.LogPrefix}] Dropped pending '{pending.Keyword}' — already bookmarked by another keyword");
                         toRemove.Add(bookmarkType);
                         continue;
                     }
 
-                    _lastEventTime[bookmarkType] = pending.DetectedAtUtc;
+                    _lastEventTime[pending.CooldownGroup] = pending.DetectedAtUtc;
                     AddBookmark(bookmarkType, pending.DetectedAtLocal);
                     Log.Information($"[{_config.LogPrefix}] Confirmed '{pending.Keyword}' in OCR text -> {bookmarkType}");
                     toRemove.Add(bookmarkType);
@@ -380,6 +419,11 @@ namespace Segra.Backend.Games
 
             foreach (var key in toRemove)
                 _pendingEvents.Remove(key);
+        }
+
+        private static string GetCooldownGroup(OcrKeyword keyword)
+        {
+            return keyword.CooldownGroup ?? keyword.BookmarkType.ToString();
         }
 
         private void AddBookmark(BookmarkType type, DateTime? detectionTime = null)

--- a/Frontend/src/Components/Settings/GameIntegrationsSection.tsx
+++ b/Frontend/src/Components/Settings/GameIntegrationsSection.tsx
@@ -44,6 +44,14 @@ const GAME_INTEGRATIONS: GameIntegration[] = [
     backgroundImage: 'https://segra.tv/api/games/cover/ar5u6d',
   },
   {
+    id: 'apex-legends',
+    name: 'Apex Legends',
+    settingsKey: 'apexLegends',
+    bookmarks: ['Kills', 'Assists'],
+    backgroundImage: 'https://segra.tv/api/games/cover/coc1di',
+    isBeta: true,
+  },
+  {
     id: 'gta',
     name: 'Grand Theft Auto',
     settingsKey: 'gta',
@@ -196,7 +204,7 @@ export default function GameIntegrationsSection() {
           <GameIntegrationCard
             key={integration.id}
             integration={integration}
-            enabled={settings.gameIntegrations[integration.settingsKey].enabled}
+            enabled={settings.gameIntegrations[integration.settingsKey]?.enabled ?? true}
             showBackground={settings.showGameBackground}
             isRecording={appState.recording != null || appState.preRecording != null}
             onToggle={(enabled) => handleToggle(integration.settingsKey, enabled)}

--- a/Frontend/src/Context/SettingsContext.tsx
+++ b/Frontend/src/Context/SettingsContext.tsx
@@ -31,13 +31,22 @@ interface SettingsProviderProps {
   children: ReactNode;
 }
 
+const mergeSettingsWithDefaults = (value: Partial<Settings>): Settings => ({
+  ...initialSettings,
+  ...value,
+  gameIntegrations: {
+    ...initialSettings.gameIntegrations,
+    ...value.gameIntegrations,
+  },
+});
+
 export function SettingsProvider({ children }: SettingsProviderProps) {
   const loadCachedSettings = (): Settings | null => {
     try {
       const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
       if (!raw) return null;
       const cached = JSON.parse(raw);
-      return { ...initialSettings, ...cached };
+      return mergeSettingsWithDefaults(cached);
     } catch {
       return null;
     }
@@ -59,7 +68,15 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
   const updateSettings = useCallback<SettingsUpdateContextType>(
     (newSettings, fromBackend = false) => {
       setSettings((prev) => {
-        const updatedSettings: Settings = { ...prev, ...newSettings };
+        const updatedSettings: Settings = {
+          ...prev,
+          ...newSettings,
+          gameIntegrations: {
+            ...initialSettings.gameIntegrations,
+            ...prev.gameIntegrations,
+            ...newSettings.gameIntegrations,
+          },
+        };
         saveCachedSettings(updatedSettings);
         if (!fromBackend) {
           pendingBackendUpdateRef.current = updatedSettings;

--- a/Frontend/src/Models/types.ts
+++ b/Frontend/src/Models/types.ts
@@ -191,6 +191,7 @@ export interface GameIntegrations {
   leagueOfLegends: GameIntegrationSettings;
   pubg: GameIntegrationSettings;
   rocketLeague: GameIntegrationSettings;
+  apexLegends: GameIntegrationSettings;
   dota2: GameIntegrationSettings;
   rust: GameIntegrationSettings;
   minecraft: GameIntegrationSettings;
@@ -413,6 +414,7 @@ export const initialSettings: Settings = {
     leagueOfLegends: { enabled: true },
     pubg: { enabled: true },
     rocketLeague: { enabled: false },
+    apexLegends: { enabled: true },
     dota2: { enabled: true },
     rust: { enabled: true },
     minecraft: { enabled: true },

--- a/Segra.csproj
+++ b/Segra.csproj
@@ -102,6 +102,7 @@
     <Compile Remove="Backend\Games\OcrIntegration.cs" />
     <Compile Remove="Backend\Games\GrandTheftAuto\GtaIntegration.cs" />
     <Compile Remove="Backend\Games\RocketLeague\RocketLeagueIntegration.cs" />
+    <Compile Remove="Backend\Games\ApexLegends\**\*.cs" />
     <Compile Remove="Backend\Platform\Windows\**\*.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds Apex Legends as a Windows OCR game integration for automatic highlight bookmarks.

The integration detects Apex combat moments from on-screen OCR text:

- `KNOCKED DOWN`
- `SQUAD WIPE`
- `ELIMINATED`
- `ASSIST ELIMINATION`
- `YOU ARE THE CHAMPION`

It also adds Apex to the game integration settings UI and makes cached frontend settings merge newly-added integration keys with defaults, so existing installs do not miss new integrations after an update.

## Notes

The `CooldownGroup` option keeps existing behavior unchanged by default, while allowing Apex's victory banner to be detected immediately after a `SQUAD WIPE`. Both currently map to `BookmarkType.Kill` so they are included in highlights, but they represent different on-screen events and can appear within the same cooldown window.

Longer term, a dedicated `Victory`/`Win` bookmark type would be cleaner, but that would require a larger backend/frontend UI change.
