### PR TITLE
Add confirmation dialogs for delete actions

### DIFF
--- a/Backend/App/DiagnosticsService.cs
+++ b/Backend/App/DiagnosticsService.cs
@@ -452,6 +452,7 @@ namespace Segra.Backend.App
             Log.Information($"Auto generate highlights: {s.AutoGenerateHighlights}");
             Log.Information($"Run on startup: {s.RunOnStartup}");
             Log.Information($"Receive beta updates: {s.ReceiveBetaUpdates}");
+            Log.Information($"Confirm before deleting: {s.ConfirmBeforeDeleting}");
             Log.Information($"Remove original after compression: {s.RemoveOriginalAfterCompression}");
             Log.Information($"Discard sessions without bookmarks: {s.DiscardSessionsWithoutBookmarks}");
         }

--- a/Backend/Core/Models/Settings.cs
+++ b/Backend/Core/Models/Settings.cs
@@ -80,6 +80,7 @@ namespace Segra.Backend.Core.Models
         private bool _inputNoiseSuppression = true;
         private string _videoQualityPreset = "high";
         private string _clipQualityPreset = "standard";
+        private bool _confirmBeforeDeleting = false;
         private bool _removeOriginalAfterCompression = false;
         private bool _discardSessionsWithoutBookmarks = false;
         private bool _disableWindowsGameMode = false;
@@ -834,6 +835,19 @@ namespace Segra.Backend.Core.Models
                 if (_clipQualityPreset != value)
                 {
                     _clipQualityPreset = value;
+                }
+            }
+        }
+
+        [JsonPropertyName("confirmBeforeDeleting")]
+        public bool ConfirmBeforeDeleting
+        {
+            get => _confirmBeforeDeleting;
+            set
+            {
+                if (_confirmBeforeDeleting != value)
+                {
+                    _confirmBeforeDeleting = value;
                 }
             }
         }

--- a/Backend/Core/SettingsService.cs
+++ b/Backend/Core/SettingsService.cs
@@ -339,6 +339,13 @@ namespace Segra.Backend.Core
                 hasChanges = true;
             }
 
+            if (settings.ConfirmBeforeDeleting != updatedSettings.ConfirmBeforeDeleting)
+            {
+                Log.Information($"ConfirmBeforeDeleting changed from '{settings.ConfirmBeforeDeleting}' to '{updatedSettings.ConfirmBeforeDeleting}'");
+                settings.ConfirmBeforeDeleting = updatedSettings.ConfirmBeforeDeleting;
+                hasChanges = true;
+            }
+
             if (settings.RemoveOriginalAfterCompression != updatedSettings.RemoveOriginalAfterCompression)
             {
                 Log.Information($"RemoveOriginalAfterCompression changed from '{settings.RemoveOriginalAfterCompression}' to '{updatedSettings.RemoveOriginalAfterCompression}'");

--- a/Frontend/src/Components/ContentCard.tsx
+++ b/Frontend/src/Components/ContentCard.tsx
@@ -24,6 +24,7 @@ import {
 import { useAiHighlights } from '../Context/AiHighlightsContext';
 import { useCompression } from '../Context/CompressionContext';
 import Button from './Button';
+import { useDeleteConfirmation } from '../Hooks/useDeleteConfirmation';
 
 type VideoType = 'Session' | 'Buffer' | 'Clip' | 'Highlight';
 
@@ -60,6 +61,7 @@ export default function ContentCard({
   const { openModal, closeModal } = useModal();
   const { aiProgress } = useAiHighlights();
   const { compressionProgress, isCompressing } = useCompression();
+  const confirmDelete = useDeleteConfirmation();
 
   const isBeingCompressed = content?.filePath ? isCompressing(content.filePath) : false;
   const currentCompressionProgress = content?.filePath
@@ -293,7 +295,18 @@ export default function ContentCard({
       ContentType: type,
     };
 
-    sendMessageToBackend('DeleteContent', parameters);
+    const displayName = content!.title || content!.game || content!.fileName;
+    confirmDelete({
+      title: `Delete ${type.toLowerCase()}?`,
+      description: (
+        <>
+          Are you sure you want to permanently delete <strong>{displayName}</strong>?
+          <br />
+          <span className="text-sm text-gray-400">This action cannot be undone.</span>
+        </>
+      ),
+      onConfirm: () => sendMessageToBackend('DeleteContent', parameters),
+    });
   };
 
   const startRenaming = () => {

--- a/Frontend/src/Components/ContentPage.tsx
+++ b/Frontend/src/Components/ContentPage.tsx
@@ -12,6 +12,7 @@ import ContentFilters, { SortOption } from './ContentFilters';
 import { useModal } from '../Context/ModalContext';
 import { useImports } from '../Context/ImportContext';
 import Button from './Button';
+import { useDeleteConfirmation } from '../Hooks/useDeleteConfirmation';
 
 // Escape a filename for use inside a CSS attribute-selector string. Windows
 // filenames can't contain " or \, but escape defensively all the same.
@@ -40,6 +41,7 @@ export default function ContentPage({
   const { setSelectedVideo } = useSelectedVideo();
   const { scrollPositions, setScrollPosition } = useScroll();
   const { isModalOpen } = useModal();
+  const confirmDelete = useDeleteConfirmation();
   const { imports } = useImports();
   const containerRef = useRef<HTMLDivElement>(null);
   const isSettingScroll = useRef(false);
@@ -168,9 +170,16 @@ export default function ContentPage({
       ContentType: contentType,
     }));
 
-    sendMessageToBackend('DeleteMultipleContent', { Items: items });
-    setSelectedItems(new Set());
-  }, [selectedItems, contentType]);
+    const count = items.length;
+    confirmDelete({
+      title: `Delete ${count} ${count === 1 ? 'item' : 'items'}?`,
+      description: `Are you sure you want to permanently delete the selected ${count === 1 ? 'item' : `${count} items`}?\n\nThis action cannot be undone.`,
+      onConfirm: () => {
+        sendMessageToBackend('DeleteMultipleContent', { Items: items });
+        setSelectedItems(new Set());
+      },
+    });
+  }, [selectedItems, contentType, confirmDelete]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/Frontend/src/Components/CustomGameModal.tsx
+++ b/Frontend/src/Components/CustomGameModal.tsx
@@ -3,6 +3,7 @@ import { sendMessageToBackend } from '../Utils/MessageUtils';
 import { isSelectedGameExecutableMessage } from '../Models/WebSocketMessages';
 import { FolderOpen, Plus } from 'lucide-react';
 import Button from './Button';
+import ConfirmationModal from './ConfirmationModal';
 
 export interface CustomGameResult {
   name: string;
@@ -33,6 +34,7 @@ export default function CustomGameModal({ onSave, onClose, initialName }: Custom
   // Treat a prefilled name (e.g. from the search box) as user-provided so browsing an exe won't replace it.
   const [nameEdited, setNameEdited] = useState(!!initialName?.trim());
   const [isSelectingFile, setIsSelectingFile] = useState(false);
+  const [pathPendingRemoval, setPathPendingRemoval] = useState<string | null>(null);
   const autoOpenedRef = useRef(false);
 
   useEffect(() => {
@@ -94,7 +96,7 @@ export default function CustomGameModal({ onSave, onClose, initialName }: Custom
   };
 
   const handleRemoveCustomPath = (pathToRemove: string) => {
-    setSelectedExes((prev) => prev.filter((e) => e.path !== pathToRemove));
+    setPathPendingRemoval(pathToRemove);
   };
 
   const handleSave = () => {
@@ -115,6 +117,27 @@ export default function CustomGameModal({ onSave, onClose, initialName }: Custom
     });
     onClose();
   };
+
+  if (pathPendingRemoval) {
+    return (
+      <ConfirmationModal
+        title="Remove executable?"
+        description={
+          <>
+            Remove this executable from the custom game?
+            <br />
+            <span className="text-sm text-gray-400 break-all">{pathPendingRemoval}</span>
+          </>
+        }
+        confirmText="Remove"
+        onConfirm={() => {
+          setSelectedExes((prev) => prev.filter((e) => e.path !== pathPendingRemoval));
+          setPathPendingRemoval(null);
+        }}
+        onCancel={() => setPathPendingRemoval(null)}
+      />
+    );
+  }
 
   return (
     <>

--- a/Frontend/src/Components/CustomGameModal.tsx
+++ b/Frontend/src/Components/CustomGameModal.tsx
@@ -4,6 +4,7 @@ import { isSelectedGameExecutableMessage } from '../Models/WebSocketMessages';
 import { FolderOpen, Plus } from 'lucide-react';
 import Button from './Button';
 import ConfirmationModal from './ConfirmationModal';
+import { useSettings } from '../Context/SettingsContext';
 
 export interface CustomGameResult {
   name: string;
@@ -29,6 +30,7 @@ interface SelectedExecutable {
 }
 
 export default function CustomGameModal({ onSave, onClose, initialName }: CustomGameModalProps) {
+  const settings = useSettings();
   const [selectedExes, setSelectedExes] = useState<SelectedExecutable[]>([]);
   const [customGameName, setCustomGameName] = useState(initialName ?? '');
   // Treat a prefilled name (e.g. from the search box) as user-provided so browsing an exe won't replace it.
@@ -96,6 +98,11 @@ export default function CustomGameModal({ onSave, onClose, initialName }: Custom
   };
 
   const handleRemoveCustomPath = (pathToRemove: string) => {
+    if (!settings.confirmBeforeDeleting) {
+      setSelectedExes((prev) => prev.filter((exe) => exe.path !== pathToRemove));
+      return;
+    }
+
     setPathPendingRemoval(pathToRemove);
   };
 

--- a/Frontend/src/Components/RecoveryModal.tsx
+++ b/Frontend/src/Components/RecoveryModal.tsx
@@ -5,6 +5,7 @@ import { sendMessageToBackend } from '../Utils/MessageUtils';
 import { useAppState } from '../Context/AppStateContext';
 import Button from './Button';
 import ConfirmationModal from './ConfirmationModal';
+import { useSettings } from '../Context/SettingsContext';
 
 interface RecoveryModalProps {
   files: RecoveryFileData[];
@@ -12,6 +13,7 @@ interface RecoveryModalProps {
 }
 
 export default function RecoveryModal({ files, onClose }: RecoveryModalProps) {
+  const settings = useSettings();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [remainingFiles, setRemainingFiles] = useState(files);
   const [gameOverrides, setGameOverrides] = useState<Record<string, string>>({});
@@ -240,7 +242,12 @@ export default function RecoveryModal({ files, onClose }: RecoveryModalProps) {
         <Button variant="success" onClick={() => handleAction('recover')}>
           Recover
         </Button>
-        <Button variant="danger" onClick={() => setIsConfirmingDelete(true)}>
+        <Button
+          variant="danger"
+          onClick={() =>
+            settings.confirmBeforeDeleting ? setIsConfirmingDelete(true) : handleAction('delete')
+          }
+        >
           Delete
         </Button>
         <Button variant="primary" onClick={() => handleAction('skip')}>

--- a/Frontend/src/Components/RecoveryModal.tsx
+++ b/Frontend/src/Components/RecoveryModal.tsx
@@ -4,6 +4,7 @@ import { RecoveryFileData } from '../Models/WebSocketMessages';
 import { sendMessageToBackend } from '../Utils/MessageUtils';
 import { useAppState } from '../Context/AppStateContext';
 import Button from './Button';
+import ConfirmationModal from './ConfirmationModal';
 
 interface RecoveryModalProps {
   files: RecoveryFileData[];
@@ -16,6 +17,7 @@ export default function RecoveryModal({ files, onClose }: RecoveryModalProps) {
   const [gameOverrides, setGameOverrides] = useState<Record<string, string>>({});
   const [inputValue, setInputValue] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const appState = useAppState();
 
@@ -120,6 +122,24 @@ export default function RecoveryModal({ files, onClose }: RecoveryModalProps) {
     }
   };
 
+  if (isConfirmingDelete) {
+    return (
+      <ConfirmationModal
+        title="Delete recovered file?"
+        description={
+          <>
+            Are you sure you want to permanently delete <strong>{currentFile.fileName}</strong>?
+            <br />
+            <span className="text-sm text-gray-400">This action cannot be undone.</span>
+          </>
+        }
+        confirmText="Delete"
+        onConfirm={() => handleAction('delete')}
+        onCancel={() => setIsConfirmingDelete(false)}
+      />
+    );
+  }
+
   return (
     <>
       <div className="modal-header pb-4 border-b border-gray-700">
@@ -220,7 +240,7 @@ export default function RecoveryModal({ files, onClose }: RecoveryModalProps) {
         <Button variant="success" onClick={() => handleAction('recover')}>
           Recover
         </Button>
-        <Button variant="danger" onClick={() => handleAction('delete')}>
+        <Button variant="danger" onClick={() => setIsConfirmingDelete(true)}>
           Delete
         </Button>
         <Button variant="primary" onClick={() => handleAction('skip')}>

--- a/Frontend/src/Components/SegmentCard.tsx
+++ b/Frontend/src/Components/SegmentCard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { SegmentCardProps } from '../Models/types';
 import { useDrag, useDrop } from 'react-dnd';
 import { Headphones } from 'lucide-react';
+import { useDeleteConfirmation } from '../Hooks/useDeleteConfirmation';
 
 const DRAG_TYPE = 'SEGMENT_CARD';
 
@@ -62,6 +63,7 @@ const SegmentCard: React.FC<SegmentCardProps> = React.memo(
     };
 
     const { startTime, endTime, thumbnailDataUrl, isLoading } = segment;
+    const confirmDelete = useDeleteConfirmation();
 
     // Fade the first thumbnail in and crossfade later ones over the current
     // image, instead of flashing a loading state.
@@ -119,7 +121,11 @@ const SegmentCard: React.FC<SegmentCardProps> = React.memo(
         }}
         onContextMenu={(e) => {
           e.preventDefault();
-          removeSegment(segment.id);
+          confirmDelete({
+            title: 'Delete segment?',
+            description: 'Remove this segment from the clip? This action cannot be undone.',
+            onConfirm: () => removeSegment(segment.id),
+          });
         }}
       >
         {baseSrc ? (

--- a/Frontend/src/Components/Settings/GameDetectionSection.tsx
+++ b/Frontend/src/Components/Settings/GameDetectionSection.tsx
@@ -22,6 +22,7 @@ import {
 import { useModal } from '../../Context/ModalContext';
 import CustomGameModal from '../CustomGameModal';
 import DropdownSelect from '../DropdownSelect';
+import { useDeleteConfirmation } from '../../Hooks/useDeleteConfirmation';
 
 const BITRATE_OPTIONS = Array.from({ length: 19 }, (_, i) => (i + 2) * 5); // 10..100 Mbps
 
@@ -121,6 +122,7 @@ export default function GameDetectionSection() {
   const updateSettings = useSettingsUpdater();
   const appState = useAppState();
   const { openModal, closeModal } = useModal();
+  const confirmDelete = useDeleteConfirmation();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
@@ -254,8 +256,15 @@ export default function GameDetectionSection() {
   };
 
   const removeGame = (name: string) => {
-    updateSettings({ games: games.filter((g) => g.name !== name) });
-    if (selectedName === name) setSelectedName(null);
+    confirmDelete({
+      title: 'Remove game settings?',
+      description: `Remove ${name} and all of its recording overrides? Existing recordings will not be deleted.`,
+      confirmText: 'Remove',
+      onConfirm: () => {
+        updateSettings({ games: games.filter((g) => g.name !== name) });
+        if (selectedName === name) setSelectedName(null);
+      },
+    });
   };
 
   return (

--- a/Frontend/src/Components/Settings/PreferencesSection.tsx
+++ b/Frontend/src/Components/Settings/PreferencesSection.tsx
@@ -137,7 +137,20 @@ export default function PreferencesSection({ settings, updateSettings }: Prefere
         </label>
       </div>
 
-      {/* Disabled-by-default toggles */}
+      {/* Deletion and cleanup toggles */}
+      <div className="flex items-center">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            name="confirmBeforeDeleting"
+            checked={settings.confirmBeforeDeleting}
+            onChange={(e) => updateSettings({ confirmBeforeDeleting: e.target.checked })}
+            className="checkbox checkbox-primary checkbox-sm"
+          />
+          <span className="cursor-pointer">Confirm Before Deleting</span>
+        </label>
+      </div>
+
       <div className="flex items-center">
         <label className="flex items-center gap-2">
           <input

--- a/Frontend/src/Hooks/useDeleteConfirmation.tsx
+++ b/Frontend/src/Hooks/useDeleteConfirmation.tsx
@@ -1,0 +1,38 @@
+import { ReactNode, useCallback } from 'react';
+import ConfirmationModal from '../Components/ConfirmationModal';
+import { useModal } from '../Context/ModalContext';
+
+interface DeleteConfirmationOptions {
+  title?: string;
+  description: ReactNode;
+  confirmText?: string;
+  onConfirm: () => void;
+}
+
+export function useDeleteConfirmation() {
+  const { openModal, closeModal } = useModal();
+
+  return useCallback(
+    ({
+      title = 'Delete this item?',
+      description,
+      confirmText = 'Delete',
+      onConfirm,
+    }: DeleteConfirmationOptions) => {
+      openModal(
+        <ConfirmationModal
+          title={title}
+          description={description}
+          confirmText={confirmText}
+          onConfirm={() => {
+            onConfirm();
+            closeModal();
+          }}
+          onCancel={closeModal}
+        />,
+        { size: 'md' },
+      );
+    },
+    [closeModal, openModal],
+  );
+}

--- a/Frontend/src/Hooks/useDeleteConfirmation.tsx
+++ b/Frontend/src/Hooks/useDeleteConfirmation.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useCallback } from 'react';
 import ConfirmationModal from '../Components/ConfirmationModal';
 import { useModal } from '../Context/ModalContext';
+import { useSettings } from '../Context/SettingsContext';
 
 interface DeleteConfirmationOptions {
   title?: string;
@@ -11,6 +12,7 @@ interface DeleteConfirmationOptions {
 
 export function useDeleteConfirmation() {
   const { openModal, closeModal } = useModal();
+  const settings = useSettings();
 
   return useCallback(
     ({
@@ -19,6 +21,11 @@ export function useDeleteConfirmation() {
       confirmText = 'Delete',
       onConfirm,
     }: DeleteConfirmationOptions) => {
+      if (!settings.confirmBeforeDeleting) {
+        onConfirm();
+        return;
+      }
+
       openModal(
         <ConfirmationModal
           title={title}
@@ -33,6 +40,6 @@ export function useDeleteConfirmation() {
         { size: 'md' },
       );
     },
-    [closeModal, openModal],
+    [closeModal, openModal, settings.confirmBeforeDeleting],
   );
 }

--- a/Frontend/src/Models/types.ts
+++ b/Frontend/src/Models/types.ts
@@ -319,6 +319,7 @@ export interface Settings {
   audioOutputMode: AudioOutputMode;
   videoQualityPreset: VideoQualityPreset;
   clipQualityPreset: ClipQualityPreset;
+  confirmBeforeDeleting: boolean;
   removeOriginalAfterCompression: boolean;
   discardSessionsWithoutBookmarks: boolean;
   disableWindowsGameMode: boolean; // When true, ensures Windows Game Mode stays off on startup
@@ -396,6 +397,7 @@ export const initialSettings: Settings = {
   audioOutputMode: 'All',
   videoQualityPreset: 'high',
   clipQualityPreset: 'standard',
+  confirmBeforeDeleting: false,
   removeOriginalAfterCompression: false,
   discardSessionsWithoutBookmarks: false,
   disableWindowsGameMode: false,

--- a/Frontend/src/Pages/video.tsx
+++ b/Frontend/src/Pages/video.tsx
@@ -47,6 +47,7 @@ import SegmentCard from '../Components/SegmentCard';
 import { useAudioTracks } from '../Hooks/useAudioTracks';
 import { AnimatePresence, motion } from 'framer-motion';
 import Button from '../Components/Button';
+import { useDeleteConfirmation } from '../Hooks/useDeleteConfirmation';
 
 const Crosshair2Dot = React.forwardRef<SVGSVGElement, React.ComponentProps<typeof Icon>>(
   (props, ref) => <Icon {...props} ref={ref} iconNode={crosshair2Dot} />,
@@ -199,6 +200,7 @@ export default function VideoComponent({ video }: { video: Content }) {
   const { session } = useAuth();
   const { uploads } = useUploads();
   const { openModal, closeModal } = useModal();
+  const confirmDelete = useDeleteConfirmation();
   const {
     segments,
     addSegment,
@@ -1602,20 +1604,46 @@ export default function VideoComponent({ video }: { video: Content }) {
     const bookmarkIndex = video.bookmarks.findIndex((b) => b.id === bookmarkId);
 
     if (bookmarkIndex !== -1) {
-      // Remove the bookmark from the array
-      video.bookmarks.splice(bookmarkIndex, 1);
+      const bookmark = video.bookmarks[bookmarkIndex];
+      confirmDelete({
+        title: 'Delete bookmark?',
+        description: `Delete the ${bookmark.type.toLowerCase()} bookmark at ${bookmark.time}? This action cannot be undone.`,
+        onConfirm: () => {
+          // Remove the bookmark from the array
+          video.bookmarks.splice(bookmarkIndex, 1);
 
-      // Force a re-render to update the UI
-      const bookmarks = [...video.bookmarks];
-      video.bookmarks = bookmarks;
+          // Force a re-render to update the UI
+          const bookmarks = [...video.bookmarks];
+          video.bookmarks = bookmarks;
 
-      // Send message to backend to delete the bookmark
-      sendMessageToBackend('DeleteBookmark', {
-        FilePath: video.filePath,
-        ContentType: video.type,
-        Id: bookmarkId,
+          // Send message to backend to delete the bookmark
+          sendMessageToBackend('DeleteBookmark', {
+            FilePath: video.filePath,
+            ContentType: video.type,
+            Id: bookmarkId,
+          });
+        },
       });
     }
+  };
+
+  const handleDeleteSegment = (segmentId: number) => {
+    confirmDelete({
+      title: 'Delete segment?',
+      description: 'Remove this segment from the clip? This action cannot be undone.',
+      onConfirm: () => removeSegment(segmentId),
+    });
+  };
+
+  const handleClearSegments = () => {
+    if (segments.length === 0) return;
+
+    confirmDelete({
+      title: 'Delete all segments?',
+      description: `Remove all ${segments.length} ${segments.length === 1 ? 'segment' : 'segments'} from the clip? This action cannot be undone.`,
+      confirmText: 'Delete all',
+      onConfirm: clearAllSegments,
+    });
   };
 
   // Handle volume change
@@ -2050,7 +2078,7 @@ export default function VideoComponent({ video }: { video: Content }) {
                     onMouseDown={(e) => handleSegmentMouseDown(e, seg.id)}
                     onContextMenu={(e) => {
                       e.preventDefault();
-                      removeSegment(seg.id);
+                      handleDeleteSegment(seg.id);
                     }}
                   >
                     <div className="absolute left-0 top-0 h-full w-[4px] bg-accent/80 rounded-l-sm pointer-events-none" />
@@ -2458,7 +2486,7 @@ export default function VideoComponent({ video }: { video: Content }) {
                 variant="primary"
                 size="sm"
                 className="w-full h-10 py-0 hover:text-accent"
-                onClick={clearAllSegments}
+                onClick={handleClearSegments}
                 disabled={segments.length === 0}
               >
                 <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
Adds a delete confirmation hook using the existing modal system.  

Confirm content deletion, bookmark and clip segment deletion, clearing all clip segments, recovery file deletion, game setting and custom executable removal.