### PR TITLE
Show storage usage in settings and menu

### DIFF
--- a/Backend/App/MessageService.cs
+++ b/Backend/App/MessageService.cs
@@ -196,6 +196,9 @@ namespace Segra.Backend.App
                         case "StopRecording":
                             _ = Task.Run(OBSService.StopRecording);
                             break;
+                        case "RefreshStorageStats":
+                            StorageService.UpdateRecordingDriveSpaceInState();
+                            break;
                         case "NewConnection":
                             Log.Information("NewConnection command received.");
                             await SendSettingsToFrontend("New connection");

--- a/Backend/Core/Models/AppState.cs
+++ b/Backend/Core/Models/AppState.cs
@@ -27,6 +27,8 @@ namespace Segra.Backend.Core.Models
         private bool _isCheckingForUpdates = false;
         private int _maxDisplayHeight = 1080;
         private double _currentFolderSizeGb = 0;
+        private double? _recordingDriveUsedGb = null;
+        private double? _recordingDriveFreeGb = null;
 
         private IPlatformWatcher? _deviceWatcher;
         private IPlatformWatcher? _displayWatcher;
@@ -232,6 +234,28 @@ namespace Segra.Backend.Core.Models
                 {
                     SendToFrontend("State update: CurrentFolderSizeGb");
                 }
+            }
+        }
+
+        [JsonPropertyName("recordingDriveUsedGb")]
+        public double? RecordingDriveUsedGb => _recordingDriveUsedGb;
+
+        [JsonPropertyName("recordingDriveFreeGb")]
+        public double? RecordingDriveFreeGb => _recordingDriveFreeGb;
+
+        public void SetRecordingDriveSpaceGb(double? usedGb, double? freeGb, bool sendToFrontend)
+        {
+            bool changed = _recordingDriveUsedGb != usedGb || _recordingDriveFreeGb != freeGb;
+            if (!changed)
+            {
+                return;
+            }
+
+            _recordingDriveUsedGb = usedGb;
+            _recordingDriveFreeGb = freeGb;
+            if (sendToFrontend)
+            {
+                SendToFrontend("State update: Recording drive space");
             }
         }
 

--- a/Backend/Recorder/OBSService.cs
+++ b/Backend/Recorder/OBSService.cs
@@ -2472,6 +2472,13 @@ namespace Segra.Backend.Recorder
         {
             try
             {
+                var driveSpace = StorageService.GetContentDriveSpaceGb();
+                AppState.Instance.SetRecordingDriveSpaceGb(
+                    driveSpace?.UsedGb,
+                    driveSpace?.FreeGb,
+                    sendToFrontend: true
+                );
+
                 long? freeBytes = StorageService.GetContentDriveFreeBytes();
                 if (freeBytes == null || freeBytes.Value >= GetRecordingFreeSpaceThresholdBytes())
                     return;

--- a/Backend/Windows/Storage/StorageService.cs
+++ b/Backend/Windows/Storage/StorageService.cs
@@ -76,6 +76,30 @@ namespace Segra.Backend.Windows.Storage
             }
         }
 
+        public static (double UsedGb, double FreeGb)? GetContentDriveSpaceGb()
+        {
+            try
+            {
+                string contentFolder = Settings.Instance.ContentFolder;
+                if (string.IsNullOrEmpty(contentFolder)) return null;
+
+                string? root = Path.GetPathRoot(contentFolder);
+                if (string.IsNullOrEmpty(root)) return null;
+
+                var drive = new DriveInfo(root);
+                if (!drive.IsReady || drive.TotalSize <= 0) return null;
+
+                double freeGb = drive.AvailableFreeSpace / (double)BYTES_PER_GB;
+                double usedGb = (drive.TotalSize - drive.AvailableFreeSpace) / (double)BYTES_PER_GB;
+                return (Math.Round(usedGb, 2), Math.Round(freeGb, 2));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning($"Error reading content drive space: {ex.Message}");
+                return null;
+            }
+        }
+
         // Checks the system (C:), recording (content folder) and temp drives.
         // Returns any drive that is at or above DriveFullThresholdPercent, deduplicated by drive root.
         public static List<FullDrive> GetFullDrives()
@@ -124,7 +148,29 @@ namespace Segra.Backend.Windows.Storage
         {
             double currentSizeGb = GetCurrentFolderSizeGb();
             AppState.Instance.SetCurrentFolderSizeGb(currentSizeGb, sendToFrontend);
+            UpdateRecordingDriveSpaceInState(sendToFrontend);
             Log.Information($"Updated folder size in state: {currentSizeGb:F2} GB");
+        }
+
+        public static void UpdateRecordingDriveSpaceInState(bool sendToFrontend = true)
+        {
+            var driveSpace = GetContentDriveSpaceGb();
+            AppState.Instance.SetRecordingDriveSpaceGb(
+                driveSpace?.UsedGb,
+                driveSpace?.FreeGb,
+                sendToFrontend
+            );
+
+            if (driveSpace != null)
+            {
+                Log.Information(
+                    $"Updated recording drive space in state: {driveSpace.Value.UsedGb:F2} GB used, {driveSpace.Value.FreeGb:F2} GB free"
+                );
+            }
+            else
+            {
+                Log.Warning("Recording drive space is unavailable");
+            }
         }
 
         public static async Task EnsureStorageBelowLimit()

--- a/Frontend/src/Components/Settings/StorageSettingsSection.tsx
+++ b/Frontend/src/Components/Settings/StorageSettingsSection.tsx
@@ -39,10 +39,32 @@ export default function StorageSettingsSection({
   const { isMigrating } = useContentMigration();
   const [localStorageLimit, setLocalStorageLimit] = useState<string>(String(settings.storageLimit));
   const { openModal, closeModal } = useModal();
+  const driveUsedGb = appState.recordingDriveUsedGb;
+  const driveFreeGb = appState.recordingDriveFreeGb;
+  const hasDriveSpace = driveUsedGb !== null && driveFreeGb !== null;
+  const driveTotalGb =
+    driveUsedGb !== null && driveFreeGb !== null ? driveUsedGb + driveFreeGb : null;
+  const driveUsedPercent =
+    driveTotalGb && driveTotalGb > 0 && driveUsedGb !== null
+      ? Math.min(100, (driveUsedGb / driveTotalGb) * 100)
+      : 0;
+  const driveFreePercent = 100 - driveUsedPercent;
+  const driveBarColor =
+    driveFreePercent <= 5 ? 'bg-error' : driveFreePercent <= 10 ? 'bg-warning' : 'bg-primary';
+
+  const formatGigabytes = (value: number) => {
+    if (value >= 100) return value.toFixed(0);
+    if (value >= 10) return value.toFixed(1);
+    return value.toFixed(2);
+  };
 
   useEffect(() => {
     setLocalStorageLimit(String(settings.storageLimit));
   }, [settings.storageLimit]);
+
+  useEffect(() => {
+    sendMessageToBackend('RefreshStorageStats');
+  }, []);
 
   // Content whose video file is stored outside the current recording path (left behind after
   // the recording path was changed). The migration button below offers to consolidate it.
@@ -204,6 +226,29 @@ export default function StorageSettingsSection({
             min="1"
             className="input input-bordered bg-base-200 w-full block outline-none focus:border-base-400"
           />
+        </div>
+
+        <div className="form-control">
+          <label className="label flex w-full justify-between px-0 pb-1">
+            <span className="label-text flex items-center gap-2 text-base-content">
+              Storage Usage
+            </span>
+            <span className="label-text-alt text-base-content/60">
+              {hasDriveSpace ? `${Math.round(driveUsedPercent)}% used` : 'Checking...'}
+            </span>
+          </label>
+          <div className="flex h-12 flex-col justify-center gap-1.5 rounded-lg border border-base-400 bg-base-200 px-3">
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-base-400">
+              <div
+                className={`h-full rounded-full transition-all duration-300 ${driveBarColor}`}
+                style={{ width: `${driveUsedPercent}%` }}
+              />
+            </div>
+            <div className="flex justify-between text-xs text-base-content/60 tabular-nums">
+              <span>{hasDriveSpace ? `${formatGigabytes(driveUsedGb)} GB used` : '— GB used'}</span>
+              <span>{hasDriveSpace ? `${formatGigabytes(driveFreeGb)} GB free` : '— GB free'}</span>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/Frontend/src/Models/types.ts
+++ b/Frontend/src/Models/types.ts
@@ -47,6 +47,8 @@ export interface State {
   gameList: GameListEntry[];
   maxDisplayHeight: number;
   currentFolderSizeGb: number;
+  recordingDriveUsedGb: number | null;
+  recordingDriveFreeGb: number | null;
   cacheFolder: string;
 }
 
@@ -340,6 +342,8 @@ export const initialState: State = {
   gameList: [],
   maxDisplayHeight: 1080,
   currentFolderSizeGb: 0,
+  recordingDriveUsedGb: null,
+  recordingDriveFreeGb: null,
   cacheFolder: '',
 };
 

--- a/Frontend/src/menu.tsx
+++ b/Frontend/src/menu.tsx
@@ -25,7 +25,6 @@ import {
   Crown,
   Monitor,
   Play,
-  HardDrive,
   LucideIcon,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -55,24 +54,6 @@ export default function Menu({ selectedMenu, onSelectMenu }: MenuProps) {
   const { obsDownloadProgress } = useObsDownload();
   const { migrations: contentMigrations, isMigrating } = useContentMigration();
   const [buttonCooldown, setButtonCooldown] = useState(false);
-  const driveUsedGb = appState.recordingDriveUsedGb;
-  const driveFreeGb = appState.recordingDriveFreeGb;
-  const hasDriveSpace = driveUsedGb !== null && driveFreeGb !== null;
-  const driveTotalGb =
-    driveUsedGb !== null && driveFreeGb !== null ? driveUsedGb + driveFreeGb : null;
-  const driveUsedPercent =
-    driveTotalGb && driveTotalGb > 0 && driveUsedGb !== null
-      ? Math.min(100, (driveUsedGb / driveTotalGb) * 100)
-      : 0;
-  const driveFreePercent = 100 - driveUsedPercent;
-  const driveBarColor =
-    driveFreePercent <= 5 ? 'bg-error' : driveFreePercent <= 10 ? 'bg-warning' : 'bg-primary';
-
-  const formatGigabytes = (value: number) => {
-    if (value >= 100) return value.toFixed(0);
-    if (value >= 10) return value.toFixed(1);
-    return value.toFixed(2);
-  };
 
   const buttonRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const [indicatorPosition, setIndicatorPosition] = useState({ top: 12 });
@@ -113,10 +94,6 @@ export default function Menu({ selectedMenu, onSelectMenu }: MenuProps) {
   // snaps the indicator to the correct row without animating from the default top.
   useEffect(() => {
     setIndicatorAnimated(true);
-  }, []);
-
-  useEffect(() => {
-    sendMessageToBackend('RefreshStorageStats');
   }, []);
 
   const aiProgressValues = Object.values(aiProgress);
@@ -321,27 +298,6 @@ export default function Menu({ selectedMenu, onSelectMenu }: MenuProps) {
       {/* Start and Stop Buttons */}
       <div className="mb-4 px-4">
         <div className="flex flex-col items-center z-50">
-          <div className="w-full mb-2 px-2.5 py-2 rounded-lg border border-base-400">
-            <div className="flex items-center justify-between mb-1.5 text-xs">
-              <span className="flex items-center gap-1.5 text-gray-300 font-medium">
-                <HardDrive className="w-3.5 h-3.5" />
-                Storage
-              </span>
-              <span className="text-gray-500">
-                {hasDriveSpace ? `${Math.round(driveUsedPercent)}% used` : 'Checking...'}
-              </span>
-            </div>
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-base-400">
-              <div
-                className={`h-full rounded-full transition-all duration-300 ${driveBarColor}`}
-                style={{ width: `${driveUsedPercent}%` }}
-              />
-            </div>
-            <div className="flex justify-between mt-1.5 text-[11px] text-gray-400 tabular-nums">
-              <span>{hasDriveSpace ? `${formatGigabytes(driveUsedGb)} GB used` : '— GB used'}</span>
-              <span>{hasDriveSpace ? `${formatGigabytes(driveFreeGb)} GB free` : '— GB free'}</span>
-            </div>
-          </div>
           <Button
             variant="primary"
             className="w-full h-12"

--- a/Frontend/src/menu.tsx
+++ b/Frontend/src/menu.tsx
@@ -25,6 +25,7 @@ import {
   Crown,
   Monitor,
   Play,
+  HardDrive,
   LucideIcon,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -54,6 +55,24 @@ export default function Menu({ selectedMenu, onSelectMenu }: MenuProps) {
   const { obsDownloadProgress } = useObsDownload();
   const { migrations: contentMigrations, isMigrating } = useContentMigration();
   const [buttonCooldown, setButtonCooldown] = useState(false);
+  const driveUsedGb = appState.recordingDriveUsedGb;
+  const driveFreeGb = appState.recordingDriveFreeGb;
+  const hasDriveSpace = driveUsedGb !== null && driveFreeGb !== null;
+  const driveTotalGb =
+    driveUsedGb !== null && driveFreeGb !== null ? driveUsedGb + driveFreeGb : null;
+  const driveUsedPercent =
+    driveTotalGb && driveTotalGb > 0 && driveUsedGb !== null
+      ? Math.min(100, (driveUsedGb / driveTotalGb) * 100)
+      : 0;
+  const driveFreePercent = 100 - driveUsedPercent;
+  const driveBarColor =
+    driveFreePercent <= 5 ? 'bg-error' : driveFreePercent <= 10 ? 'bg-warning' : 'bg-primary';
+
+  const formatGigabytes = (value: number) => {
+    if (value >= 100) return value.toFixed(0);
+    if (value >= 10) return value.toFixed(1);
+    return value.toFixed(2);
+  };
 
   const buttonRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const [indicatorPosition, setIndicatorPosition] = useState({ top: 12 });
@@ -94,6 +113,10 @@ export default function Menu({ selectedMenu, onSelectMenu }: MenuProps) {
   // snaps the indicator to the correct row without animating from the default top.
   useEffect(() => {
     setIndicatorAnimated(true);
+  }, []);
+
+  useEffect(() => {
+    sendMessageToBackend('RefreshStorageStats');
   }, []);
 
   const aiProgressValues = Object.values(aiProgress);
@@ -298,6 +321,27 @@ export default function Menu({ selectedMenu, onSelectMenu }: MenuProps) {
       {/* Start and Stop Buttons */}
       <div className="mb-4 px-4">
         <div className="flex flex-col items-center z-50">
+          <div className="w-full mb-2 px-2.5 py-2 rounded-lg border border-base-400">
+            <div className="flex items-center justify-between mb-1.5 text-xs">
+              <span className="flex items-center gap-1.5 text-gray-300 font-medium">
+                <HardDrive className="w-3.5 h-3.5" />
+                Storage
+              </span>
+              <span className="text-gray-500">
+                {hasDriveSpace ? `${Math.round(driveUsedPercent)}% used` : 'Checking...'}
+              </span>
+            </div>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-base-400">
+              <div
+                className={`h-full rounded-full transition-all duration-300 ${driveBarColor}`}
+                style={{ width: `${driveUsedPercent}%` }}
+              />
+            </div>
+            <div className="flex justify-between mt-1.5 text-[11px] text-gray-400 tabular-nums">
+              <span>{hasDriveSpace ? `${formatGigabytes(driveUsedGb)} GB used` : '— GB used'}</span>
+              <span>{hasDriveSpace ? `${formatGigabytes(driveFreeGb)} GB free` : '— GB free'}</span>
+            </div>
+          </div>
           <Button
             variant="primary"
             className="w-full h-12"


### PR DESCRIPTION
Adds % and GB usage with how much free space is left in Menu and Settings

<img width="1230" height="243" alt="image" src="https://github.com/user-attachments/assets/dc121733-ae19-48f2-afc2-744df81abf98" />
