### PR TITLE
Add right-click context menus

### DIFF
--- a/Frontend/src/Components/ContentCard.tsx
+++ b/Frontend/src/Components/ContentCard.tsx
@@ -67,6 +67,7 @@ export default function ContentCard({
     : undefined;
 
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownTriggerRef = useRef<HTMLLabelElement>(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [opened, setOpened] = useState(false);
@@ -357,6 +358,7 @@ export default function ContentCard({
 
     event.preventDefault();
     event.stopPropagation();
+    (document.activeElement as HTMLElement | null)?.blur();
     window.dispatchEvent(new Event('segra:close-content-context-menus'));
 
     const menuWidth = 208;
@@ -600,7 +602,13 @@ export default function ContentCard({
             ref={dropdownRef}
             className={`dropdown dropdown-end ${isBeingCompressed ? 'pointer-events-none opacity-50' : ''}`}
             onClick={(e) => e.stopPropagation()}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              dropdownTriggerRef.current?.focus();
+            }}
             onFocus={() => {
+              window.dispatchEvent(new Event('segra:close-content-context-menus'));
               updateDropdownPosition();
               setIsDropdownOpen(true);
             }}
@@ -612,6 +620,7 @@ export default function ContentCard({
             }}
           >
             <label
+              ref={dropdownTriggerRef}
               tabIndex={isBeingCompressed ? -1 : 0}
               className="btn btn-ghost btn-sm btn-circle hover:bg-white/10 active:bg-white/10"
             >

--- a/Frontend/src/Components/ContentCard.tsx
+++ b/Frontend/src/Components/ContentCard.tsx
@@ -72,7 +72,12 @@ export default function ContentCard({
   const [opened, setOpened] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState('');
+  const [contextMenuPosition, setContextMenuPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const uploadModalSequenceRef = useRef(0);
 
   const thumbnailRef = useRef<HTMLImageElement>(null);
   const thumbnailKey = `${type}:${content?.fileName ?? ''}`;
@@ -257,9 +262,10 @@ export default function ContentCard({
   };
 
   const handleUpload = () => {
+    uploadModalSequenceRef.current += 1;
     openModal(
       <UploadModal
-        key={`${Math.random()}`}
+        key={`${content!.fileName}-${uploadModalSequenceRef.current}`}
         video={content!}
         onClose={closeModal}
         onUpload={(title, description, visibility) => {
@@ -320,6 +326,170 @@ export default function ContentCard({
 
   const handleOpenFileLocation = () => openFileLocation(content!.filePath);
 
+  useEffect(() => {
+    if (!contextMenuPosition) return;
+
+    const closeContextMenu = () => setContextMenuPosition(null);
+    window.addEventListener('click', closeContextMenu);
+    window.addEventListener('blur', closeContextMenu);
+    window.addEventListener('resize', closeContextMenu);
+    window.addEventListener('scroll', closeContextMenu, true);
+
+    return () => {
+      window.removeEventListener('click', closeContextMenu);
+      window.removeEventListener('blur', closeContextMenu);
+      window.removeEventListener('resize', closeContextMenu);
+      window.removeEventListener('scroll', closeContextMenu, true);
+    };
+  }, [contextMenuPosition]);
+
+  useEffect(() => {
+    const closeContextMenu = () => setContextMenuPosition(null);
+    window.addEventListener('segra:close-content-context-menus', closeContextMenu);
+
+    return () => {
+      window.removeEventListener('segra:close-content-context-menus', closeContextMenu);
+    };
+  }, []);
+
+  const openContextMenu = (event: React.MouseEvent) => {
+    if (isBeingCompressed) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    window.dispatchEvent(new Event('segra:close-content-context-menus'));
+
+    const menuWidth = 208;
+    const actionCount =
+      3 +
+      (!airplaneMode && (type === 'Clip' || type === 'Highlight') ? 1 : 0) +
+      (type === 'Clip' || type === 'Highlight' || type === 'Buffer' ? 1 : 0) +
+      (type === 'Session' && enableAi ? 1 : 0) +
+      ((type === 'Clip' || type === 'Highlight') && !content?.fileName?.endsWith('_compressed')
+        ? 1
+        : 0);
+    const menuHeight = actionCount * 40 + 16;
+    setContextMenuPosition({
+      x: Math.max(8, Math.min(event.clientX, window.innerWidth - menuWidth - 8)),
+      y: Math.max(8, Math.min(event.clientY, window.innerHeight - menuHeight - 8)),
+    });
+  };
+
+  const hasHighlightBookmarks = content?.bookmarks?.some((bookmark) =>
+    includeInHighlight(bookmark.type),
+  );
+  const isCreatingHighlight = Object.values(aiProgress).some(
+    (progress) =>
+      progress.content.fileName === content?.fileName && progress.status === 'processing',
+  );
+
+  const renderMenuItems = (closeMenu: () => void) => (
+    <>
+      {!airplaneMode && (type === 'Clip' || type === 'Highlight') && (
+        <li>
+          <Button
+            variant="menuPrimary"
+            onClick={() => {
+              closeMenu();
+              handleUpload();
+            }}
+          >
+            <Upload size={20} />
+            <span>Upload</span>
+          </Button>
+        </li>
+      )}
+      {(type === 'Clip' || type === 'Highlight' || type === 'Buffer') && (
+        <li>
+          <Button
+            variant="menu"
+            onClick={() => {
+              closeMenu();
+              sendMessageToBackend('CopyFileToClipboard', {
+                FilePath: content!.filePath,
+              });
+            }}
+          >
+            <Copy size={20} />
+            <span>Copy</span>
+          </Button>
+        </li>
+      )}
+      {type === 'Session' && enableAi && (
+        <li>
+          <Button
+            variant="menuPurple"
+            disabled={!hasHighlightBookmarks || isCreatingHighlight}
+            onClick={() => {
+              if (!hasHighlightBookmarks || isCreatingHighlight) return;
+              closeMenu();
+              handleCreateAiClip();
+            }}
+          >
+            <Crown size={20} />
+            <span>
+              {isCreatingHighlight
+                ? 'Creating Highlight...'
+                : hasHighlightBookmarks
+                  ? 'Create Highlight'
+                  : 'No Highlights'}
+            </span>
+          </Button>
+        </li>
+      )}
+      <li>
+        <Button
+          variant="menu"
+          onClick={() => {
+            closeMenu();
+            startRenaming();
+          }}
+        >
+          <PenLine size={20} />
+          <span>Rename</span>
+        </Button>
+      </li>
+      <li>
+        <Button
+          variant="menu"
+          onClick={() => {
+            closeMenu();
+            handleOpenFileLocation();
+          }}
+        >
+          <FolderOpen size={20} />
+          <span>Open File Location</span>
+        </Button>
+      </li>
+      {(type === 'Clip' || type === 'Highlight') && !content?.fileName?.endsWith('_compressed') && (
+        <li>
+          <Button
+            variant="menu"
+            onClick={() => {
+              closeMenu();
+              sendMessageToBackend('CompressVideo', { FilePath: content!.filePath });
+            }}
+          >
+            <Minimize2 size={20} />
+            <span>Compress</span>
+          </Button>
+        </li>
+      )}
+      <li>
+        <Button
+          variant="menuDanger"
+          onClick={() => {
+            closeMenu();
+            handleDelete();
+          }}
+        >
+          <Trash2 size={20} />
+          <span>Delete</span>
+        </Button>
+      </li>
+    </>
+  );
+
   return (
     <div
       data-content-filename={content!.fileName}
@@ -329,6 +499,7 @@ export default function ContentCard({
         if (!isSelectionMode) markAsViewed();
         onClick?.(content!);
       }}
+      onContextMenu={openContextMenu}
     >
       <figure className="relative aspect-video bg-black">
         {/* Shimmer crossfades out as the image fades in, so the figure never flashes black. */}
@@ -450,124 +621,7 @@ export default function ContentCard({
               tabIndex={0}
               className="dropdown-content menu bg-base-300 border border-base-400 rounded-box z-999 w-52 p-2"
             >
-              {!airplaneMode && (type === 'Clip' || type === 'Highlight') && (
-                <li>
-                  <Button
-                    variant="menuPrimary"
-                    onClick={() => {
-                      (document.activeElement as HTMLElement).blur();
-                      handleUpload();
-                    }}
-                  >
-                    <Upload size={20} />
-                    <span>Upload</span>
-                  </Button>
-                </li>
-              )}
-              {(type === 'Clip' || type === 'Highlight' || type === 'Buffer') && (
-                <li>
-                  <Button
-                    variant="menu"
-                    onClick={() => {
-                      (document.activeElement as HTMLElement).blur();
-                      sendMessageToBackend('CopyFileToClipboard', {
-                        FilePath: content!.filePath,
-                      });
-                    }}
-                  >
-                    <Copy size={20} />
-                    <span>Copy</span>
-                  </Button>
-                </li>
-              )}
-              {type === 'Session' && enableAi && (
-                <li>
-                  {(() => {
-                    const hasHighlightBookmarks = content?.bookmarks?.some((b) =>
-                      includeInHighlight(b.type),
-                    );
-                    const isProcessing = Object.values(aiProgress).some(
-                      (progress) =>
-                        progress.content.fileName === content?.fileName &&
-                        progress.status === 'processing',
-                    );
-                    const isDisabled = !hasHighlightBookmarks || isProcessing;
-
-                    return (
-                      <Button
-                        variant="menuPurple"
-                        disabled={isDisabled}
-                        onClick={() => {
-                          if (hasHighlightBookmarks && !isProcessing) {
-                            (document.activeElement as HTMLElement).blur();
-                            handleCreateAiClip();
-                          }
-                        }}
-                      >
-                        <Crown size={20} />
-                        <span>
-                          {isProcessing
-                            ? 'Creating Highlight...'
-                            : hasHighlightBookmarks
-                              ? 'Create Highlight'
-                              : 'No Highlights'}
-                        </span>
-                      </Button>
-                    );
-                  })()}
-                </li>
-              )}
-              <li>
-                <Button
-                  variant="menu"
-                  onClick={() => {
-                    (document.activeElement as HTMLElement).blur();
-                    startRenaming();
-                  }}
-                >
-                  <PenLine size={20} />
-                  <span>Rename</span>
-                </Button>
-              </li>
-              <li>
-                <Button
-                  variant="menu"
-                  onClick={() => {
-                    (document.activeElement as HTMLElement).blur();
-                    handleOpenFileLocation();
-                  }}
-                >
-                  <FolderOpen size={20} />
-                  <span>Open File Location</span>
-                </Button>
-              </li>
-              {(type === 'Clip' || type === 'Highlight') &&
-                !content?.fileName?.endsWith('_compressed') && (
-                  <li>
-                    <Button
-                      variant="menu"
-                      onClick={() => {
-                        (document.activeElement as HTMLElement).blur();
-                        sendMessageToBackend('CompressVideo', { FilePath: content!.filePath });
-                      }}
-                    >
-                      <Minimize2 size={20} />
-                      <span>Compress</span>
-                    </Button>
-                  </li>
-                )}
-              <li>
-                <Button
-                  variant="menuDanger"
-                  onClick={() => {
-                    (document.activeElement as HTMLElement).blur();
-                    handleDelete();
-                  }}
-                >
-                  <Trash2 size={20} />
-                  <span>Delete</span>
-                </Button>
-              </li>
+              {renderMenuItems(() => (document.activeElement as HTMLElement).blur())}
             </ul>
           </div>
         </div>
@@ -624,6 +678,16 @@ export default function ContentCard({
           )}
         </div>
       </div>
+
+      {contextMenuPosition && (
+        <ul
+          className="menu fixed z-1000 w-52 rounded-box border border-base-400 bg-base-300 p-2 shadow-xl"
+          style={{ left: contextMenuPosition.x, top: contextMenuPosition.y }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          {renderMenuItems(() => setContextMenuPosition(null))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/Frontend/src/main.tsx
+++ b/Frontend/src/main.tsx
@@ -25,6 +25,12 @@ const queryClient = new QueryClient({
 // Clear query cache on sign out
 onSignOut(() => queryClient.clear());
 
+// Segra provides its own context menus where right-click actions are supported.
+document.addEventListener('contextmenu', (event) => {
+  event.preventDefault();
+  window.dispatchEvent(new Event('segra:close-content-context-menus'));
+});
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Adding the support for right-click actions on items based on their context menus, re-using the three dots menu . Also right-click action is disabled on the places if there is no need for it, such as sidebar.