### PR TITLE
Clear the active filter when its final item is deleted

### DIFF
--- a/Frontend/src/Components/ContentPage.tsx
+++ b/Frontend/src/Components/ContentPage.tsx
@@ -55,7 +55,10 @@ export default function ContentPage({
   const [highlightedFileName, setHighlightedFileName] = useState<string | null>(null);
   const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const contentItems = state.content.filter((video) => video.type === contentType);
+  const contentItems = useMemo(
+    () => state.content.filter((video) => video.type === contentType),
+    [state.content, contentType],
+  );
   const [selectedGames, setSelectedGames] = useState<string[]>(() => {
     try {
       const saved = localStorage.getItem(`${sectionId}-filters`);
@@ -83,6 +86,15 @@ export default function ContentPage({
     }
     return uniqueGameList;
   }, [contentItems]);
+
+  useEffect(() => {
+    const availableFilters = new Set(uniqueGames);
+
+    setSelectedGames((prev) => {
+      const validFilters = prev.filter((game) => availableFilters.has(game));
+      return validFilters.length === prev.length ? prev : validFilters;
+    });
+  }, [uniqueGames]);
 
   const filteredItems = useMemo(() => {
     let filtered = [...contentItems];


### PR DESCRIPTION
When we filter something and we delete all of the items available in that filter, the filter disappears from the filter list but it stays active. Now the filter gets cleared if all of the items available is deleted