### PR TITLE
Always on display capture when Segra launches

### DIFF
--- a/Backend/App/MessageService.cs
+++ b/Backend/App/MessageService.cs
@@ -192,13 +192,14 @@ namespace Segra.Backend.App
                             await HandleSelectGameExecutable();
                             break;
                         case "StartRecording":
-                            if (AppState.Instance.Recording != null || AppState.Instance.PreRecording != null)
+                            if ((AppState.Instance.Recording != null && !OBSService.IsBackgroundReplayBufferActive) ||
+                                AppState.Instance.PreRecording != null)
                             {
                                 Log.Information("Recording already in progress. Skipping...");
                                 return;
                             }
 
-                            _ = Task.Run(() => OBSService.StartRecording(startManually: true));
+                            _ = Task.Run(() => OBSService.StartRecordingReplacingBackgroundBufferAsync(startManually: true));
                             break;
                         case "StopRecording":
                             _ = Task.Run(OBSService.StopRecording);

--- a/Backend/App/Program.cs
+++ b/Backend/App/Program.cs
@@ -403,7 +403,7 @@ namespace Segra.Backend.App
                 Log.Information("Active recording detected during shutdown; stopping it before exit.");
                 try
                 {
-                    Task.Run(() => OBSService.StopRecording()).GetAwaiter().GetResult();
+                    Task.Run(() => OBSService.StopRecording(restartBackgroundReplayBuffer: false)).GetAwaiter().GetResult();
                 }
                 catch (Exception ex)
                 {

--- a/Backend/App/UpdateService.cs
+++ b/Backend/App/UpdateService.cs
@@ -185,7 +185,7 @@ namespace Segra.Backend.App
                 Log.Information("Active recording detected while applying update; stopping it first.");
                 try
                 {
-                    Task.Run(() => OBSService.StopRecording()).GetAwaiter().GetResult();
+                    Task.Run(() => OBSService.StopRecording(restartBackgroundReplayBuffer: false)).GetAwaiter().GetResult();
                 }
                 catch (Exception ex)
                 {

--- a/Backend/Core/Models/AppState.cs
+++ b/Backend/Core/Models/AppState.cs
@@ -16,6 +16,7 @@ namespace Segra.Backend.Core.Models
         private GpuVendor _gpuVendor = GpuVendor.Unknown;
         private PreRecording? _preRecording = null;
         private Recording? _recording = null;
+        private bool _backgroundReplayBufferActive = false;
         private bool _hasLoadedObs = false;
         private List<Content> _content = [];
 
@@ -86,6 +87,20 @@ namespace Segra.Backend.Core.Models
                 {
                     _recording = value;
                     SendToFrontend("State update: Recording");
+                }
+            }
+        }
+
+        [JsonPropertyName("backgroundReplayBufferActive")]
+        public bool BackgroundReplayBufferActive
+        {
+            get => _backgroundReplayBufferActive;
+            set
+            {
+                if (_backgroundReplayBufferActive != value)
+                {
+                    _backgroundReplayBufferActive = value;
+                    SendToFrontend("State update: BackgroundReplayBufferActive");
                 }
             }
         }

--- a/Backend/Core/Models/Settings.cs
+++ b/Backend/Core/Models/Settings.cs
@@ -51,8 +51,7 @@ namespace Segra.Backend.Core.Models
         private double _highlightPaddingBefore = 4;
         private double _highlightPaddingAfter = 4;
         private bool _runOnStartup = false;
-        private bool _alwaysOnDisplayCapture = false;
-        private bool _alwaysOnDisplayCaptureRecordSession = false;
+        private bool _backgroundReplayBuffer = false;
         private StartupWindowMode _startupWindowMode = StartupWindowMode.Minimized;
         private CloseButtonAction _closeButtonAction = CloseButtonAction.Minimize;
         private bool _receiveBetaUpdates = false;
@@ -454,18 +453,11 @@ namespace Segra.Backend.Core.Models
             }
         }
 
-        [JsonPropertyName("alwaysOnDisplayCapture")]
-        public bool AlwaysOnDisplayCapture
+        [JsonPropertyName("backgroundReplayBuffer")]
+        public bool BackgroundReplayBuffer
         {
-            get => _alwaysOnDisplayCapture;
-            set => _alwaysOnDisplayCapture = value;
-        }
-
-        [JsonPropertyName("alwaysOnDisplayCaptureRecordSession")]
-        public bool AlwaysOnDisplayCaptureRecordSession
-        {
-            get => _alwaysOnDisplayCaptureRecordSession;
-            set => _alwaysOnDisplayCaptureRecordSession = value;
+            get => _backgroundReplayBuffer;
+            set => _backgroundReplayBuffer = value;
         }
 
         // Whether the window opens normally or stays minimized to tray when launched from startup.

--- a/Backend/Core/Models/Settings.cs
+++ b/Backend/Core/Models/Settings.cs
@@ -51,6 +51,8 @@ namespace Segra.Backend.Core.Models
         private double _highlightPaddingBefore = 4;
         private double _highlightPaddingAfter = 4;
         private bool _runOnStartup = false;
+        private bool _alwaysOnDisplayCapture = false;
+        private bool _alwaysOnDisplayCaptureRecordSession = false;
         private StartupWindowMode _startupWindowMode = StartupWindowMode.Minimized;
         private CloseButtonAction _closeButtonAction = CloseButtonAction.Minimize;
         private bool _receiveBetaUpdates = false;
@@ -450,6 +452,20 @@ namespace Segra.Backend.Core.Models
                     PlatformServices.Startup.SetStartupStatus(value);
                 }
             }
+        }
+
+        [JsonPropertyName("alwaysOnDisplayCapture")]
+        public bool AlwaysOnDisplayCapture
+        {
+            get => _alwaysOnDisplayCapture;
+            set => _alwaysOnDisplayCapture = value;
+        }
+
+        [JsonPropertyName("alwaysOnDisplayCaptureRecordSession")]
+        public bool AlwaysOnDisplayCaptureRecordSession
+        {
+            get => _alwaysOnDisplayCaptureRecordSession;
+            set => _alwaysOnDisplayCaptureRecordSession = value;
         }
 
         // Whether the window opens normally or stays minimized to tray when launched from startup.

--- a/Backend/Core/SettingsService.cs
+++ b/Backend/Core/SettingsService.cs
@@ -201,7 +201,8 @@ namespace Segra.Backend.Core
         {
             var settings = Settings.Instance;
             bool hasChanges = false;
-            bool shouldStartAlwaysOnDisplayCapture = false;
+            bool shouldStartBackgroundReplayBuffer = false;
+            bool shouldStopBackgroundReplayBuffer = false;
 
             // Begin bulk update to suppress multiple state updates
             settings.BeginBulkUpdate();
@@ -725,18 +726,12 @@ namespace Segra.Backend.Core
                 hasChanges = true;
             }
 
-            if (settings.AlwaysOnDisplayCapture != updatedSettings.AlwaysOnDisplayCapture)
+            if (settings.BackgroundReplayBuffer != updatedSettings.BackgroundReplayBuffer)
             {
-                Log.Information($"AlwaysOnDisplayCapture changed from '{settings.AlwaysOnDisplayCapture}' to '{updatedSettings.AlwaysOnDisplayCapture}'");
-                shouldStartAlwaysOnDisplayCapture = !settings.AlwaysOnDisplayCapture && updatedSettings.AlwaysOnDisplayCapture;
-                settings.AlwaysOnDisplayCapture = updatedSettings.AlwaysOnDisplayCapture;
-                hasChanges = true;
-            }
-
-            if (settings.AlwaysOnDisplayCaptureRecordSession != updatedSettings.AlwaysOnDisplayCaptureRecordSession)
-            {
-                Log.Information($"AlwaysOnDisplayCaptureRecordSession changed from '{settings.AlwaysOnDisplayCaptureRecordSession}' to '{updatedSettings.AlwaysOnDisplayCaptureRecordSession}'");
-                settings.AlwaysOnDisplayCaptureRecordSession = updatedSettings.AlwaysOnDisplayCaptureRecordSession;
+                Log.Information($"BackgroundReplayBuffer changed from '{settings.BackgroundReplayBuffer}' to '{updatedSettings.BackgroundReplayBuffer}'");
+                shouldStartBackgroundReplayBuffer = !settings.BackgroundReplayBuffer && updatedSettings.BackgroundReplayBuffer;
+                shouldStopBackgroundReplayBuffer = settings.BackgroundReplayBuffer && !updatedSettings.BackgroundReplayBuffer;
+                settings.BackgroundReplayBuffer = updatedSettings.BackgroundReplayBuffer;
                 hasChanges = true;
             }
 
@@ -814,11 +809,16 @@ namespace Segra.Backend.Core
                 Log.Information("No settings changes detected");
             }
 
-            if (shouldStartAlwaysOnDisplayCapture && OBSService.IsInitialized)
+            if (shouldStopBackgroundReplayBuffer && OBSService.IsBackgroundReplayBufferActive)
             {
-                if (!OBSService.StartAlwaysOnDisplayCapture())
+                await OBSService.StopRecording(restartBackgroundReplayBuffer: false);
+            }
+            else if (shouldStartBackgroundReplayBuffer && OBSService.IsInitialized &&
+                AppState.Instance.Recording == null && AppState.Instance.PreRecording == null)
+            {
+                if (!OBSService.StartBackgroundReplayBuffer())
                 {
-                    Log.Warning("Always-On Display Capture was enabled but could not be started immediately");
+                    Log.Warning("Background replay buffer was enabled but could not be started immediately");
                 }
             }
         }

--- a/Backend/Core/SettingsService.cs
+++ b/Backend/Core/SettingsService.cs
@@ -201,6 +201,7 @@ namespace Segra.Backend.Core
         {
             var settings = Settings.Instance;
             bool hasChanges = false;
+            bool shouldStartAlwaysOnDisplayCapture = false;
 
             // Begin bulk update to suppress multiple state updates
             settings.BeginBulkUpdate();
@@ -724,6 +725,21 @@ namespace Segra.Backend.Core
                 hasChanges = true;
             }
 
+            if (settings.AlwaysOnDisplayCapture != updatedSettings.AlwaysOnDisplayCapture)
+            {
+                Log.Information($"AlwaysOnDisplayCapture changed from '{settings.AlwaysOnDisplayCapture}' to '{updatedSettings.AlwaysOnDisplayCapture}'");
+                shouldStartAlwaysOnDisplayCapture = !settings.AlwaysOnDisplayCapture && updatedSettings.AlwaysOnDisplayCapture;
+                settings.AlwaysOnDisplayCapture = updatedSettings.AlwaysOnDisplayCapture;
+                hasChanges = true;
+            }
+
+            if (settings.AlwaysOnDisplayCaptureRecordSession != updatedSettings.AlwaysOnDisplayCaptureRecordSession)
+            {
+                Log.Information($"AlwaysOnDisplayCaptureRecordSession changed from '{settings.AlwaysOnDisplayCaptureRecordSession}' to '{updatedSettings.AlwaysOnDisplayCaptureRecordSession}'");
+                settings.AlwaysOnDisplayCaptureRecordSession = updatedSettings.AlwaysOnDisplayCaptureRecordSession;
+                hasChanges = true;
+            }
+
             if (settings.StartupWindowMode != updatedSettings.StartupWindowMode)
             {
                 Log.Information($"StartupWindowMode changed from '{settings.StartupWindowMode}' to '{updatedSettings.StartupWindowMode}'");
@@ -796,6 +812,14 @@ namespace Segra.Backend.Core
                 // End bulk update without saving if no changes were made
                 settings._isBulkUpdating = false;
                 Log.Information("No settings changes detected");
+            }
+
+            if (shouldStartAlwaysOnDisplayCapture && OBSService.IsInitialized)
+            {
+                if (!OBSService.StartAlwaysOnDisplayCapture())
+                {
+                    Log.Warning("Always-On Display Capture was enabled but could not be started immediately");
+                }
             }
         }
 

--- a/Backend/Games/GameDetectionService.cs
+++ b/Backend/Games/GameDetectionService.cs
@@ -24,6 +24,7 @@ namespace Segra.Backend.Games
 #endif
         private static readonly Dictionary<string, string> deviceToDrive = new();
         private static bool _running;
+        private static int _gameRecordingStartInProgress;
         private static System.Threading.Timer? _processCheckTimer;
 #if !WINDOWS
         // Snapshot of PIDs seen on the previous /proc scan, to synthesize start/stop events.
@@ -164,7 +165,7 @@ namespace Segra.Backend.Games
                 {
                     if (_knownPids.Contains(pid)) continue;
                     string exePath = ResolveProcessPath(pid);
-                    bool wasRecording = AppState.Instance.Recording != null;
+                    bool wasRecording = AppState.Instance.Recording != null && !OBSService.IsBackgroundReplayBufferActive;
                     HandleProcessStarted(pid, exePath);
                     // If this process just started a Steam/Proton recording, remember the game's install
                     // dir so we can stop when it closes (its Wine PIDs come and go, but all share the dir).
@@ -413,9 +414,11 @@ namespace Segra.Backend.Games
 
         private static void StartGameRecording(int pid, string exePath)
         {
-            if (AppState.Instance.Recording != null || AppState.Instance.PreRecording != null)
+            if ((AppState.Instance.Recording != null && !OBSService.IsBackgroundReplayBufferActive) ||
+                AppState.Instance.PreRecording != null ||
+                Interlocked.CompareExchange(ref _gameRecordingStartInProgress, 1, 0) != 0)
             {
-                Log.Information("[StartGameRecording] Recording already in progress. Skipping...");
+                Log.Information("[StartGameRecording] Recording already in progress or starting. Skipping...");
                 return;
             }
 
@@ -424,8 +427,73 @@ namespace Segra.Backend.Games
             string gameName = ExtractGameName(exePath);
             string? coverImageId = GameUtils.GetCoverImageIdFromExePath(exePath);
 
-            AppState.Instance.PreRecording = new PreRecording { Game = gameName, Status = "Waiting to start", CoverImageId = coverImageId, Pid = pid, Exe = exePath };
-            OBSService.StartRecording(gameName, exePath, pid: pid);
+            _ = Task.Run(async () =>
+            {
+                bool suspendedBackgroundBuffer = false;
+                try
+                {
+                    suspendedBackgroundBuffer = OBSService.IsBackgroundReplayBufferActive;
+                    if (suspendedBackgroundBuffer)
+                    {
+                        Log.Information("[StartGameRecording] Suspending background replay buffer");
+                        await OBSService.StopRecording(restartBackgroundReplayBuffer: false);
+                    }
+
+                    if (!IsProcessRunning(pid))
+                    {
+                        Log.Information("[StartGameRecording] Game exited during buffer handoff. Skipping recording.");
+                        if (suspendedBackgroundBuffer && Settings.Instance.BackgroundReplayBuffer)
+                        {
+                            OBSService.StartBackgroundReplayBuffer();
+                        }
+                        return;
+                    }
+
+                    AppState.Instance.PreRecording = new PreRecording { Game = gameName, Status = "Waiting to start", CoverImageId = coverImageId, Pid = pid, Exe = exePath };
+                    bool started = OBSService.StartRecording(gameName, exePath, pid: pid);
+                    if (!started)
+                    {
+                        if (AppState.Instance.PreRecording?.Pid == pid)
+                        {
+                            AppState.Instance.PreRecording = null;
+                        }
+
+                        if (suspendedBackgroundBuffer && Settings.Instance.BackgroundReplayBuffer)
+                        {
+                            Log.Information("[StartGameRecording] Game recording did not start; restoring background replay buffer");
+                            OBSService.StartBackgroundReplayBuffer();
+                        }
+                    }
+#if !WINDOWS
+                    else if (_recordingSteamInstallPath == null)
+                    {
+                        _recordingSteamInstallPath = SteamInstallDirFromExe(exePath);
+                    }
+#endif
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "[StartGameRecording] Failed to hand off from the background replay buffer to game recording");
+
+                    if (AppState.Instance.PreRecording?.Pid == pid)
+                    {
+                        AppState.Instance.PreRecording = null;
+                    }
+
+                    if (suspendedBackgroundBuffer &&
+                        Settings.Instance.BackgroundReplayBuffer &&
+                        AppState.Instance.Recording == null &&
+                        !OBSService.IsBackgroundReplayBufferActive)
+                    {
+                        Log.Information("[StartGameRecording] Restoring background replay buffer after handoff failure");
+                        OBSService.StartBackgroundReplayBuffer();
+                    }
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _gameRecordingStartInProgress, 0);
+                }
+            });
         }
 
 #if WINDOWS
@@ -451,7 +519,8 @@ namespace Segra.Backend.Games
 
         private static bool ShouldRecordGame(string exePath, string? fileDescription = null)
         {
-            if (string.IsNullOrEmpty(exePath) || AppState.Instance.Recording != null || AppState.Instance.PreRecording != null) return false;
+            if (string.IsNullOrEmpty(exePath) || AppState.Instance.PreRecording != null ||
+                (AppState.Instance.Recording != null && !OBSService.IsBackgroundReplayBufferActive)) return false;
 
             // Normalize path for consistent comparison
             string normalizedExePath = exePath.Replace("\\", "/");
@@ -742,7 +811,7 @@ namespace Segra.Backend.Games
             try
             {
                 // First, check if we're currently recording and if that process is still alive
-                if (AppState.Instance.Recording != null)
+                if (AppState.Instance.Recording != null && !OBSService.IsBackgroundReplayBufferActive)
                 {
                     int? recordingPid = AppState.Instance.Recording.Pid;
                     if (recordingPid.HasValue && !IsProcessRunning(recordingPid.Value))
@@ -1228,7 +1297,7 @@ namespace Segra.Backend.Games
                     // Reset retry recording flag to allow retrying recording if the user has changed foreground window
                     PreventRetryRecording = false;
 
-                    if (AppState.Instance.Recording != null) return;
+                    if (AppState.Instance.Recording != null && !OBSService.IsBackgroundReplayBufferActive) return;
 
                     // The foreground hook can fire repeatedly for the same window; skip if it matches what we last logged
                     if (hwnd == _lastLoggedHwnd) return;

--- a/Backend/Recorder/OBSService.cs
+++ b/Backend/Recorder/OBSService.cs
@@ -618,6 +618,17 @@ namespace Segra.Backend.Recorder
                 }
 
                 _ = Task.Run(RecoveryService.CheckForOrphanedFilesAsync);
+
+                // Start this before game detection so a game that is already open cannot replace
+                // the user's requested display capture with a game recording during startup.
+                if (Settings.Instance.AlwaysOnDisplayCapture)
+                {
+                    if (!StartAlwaysOnDisplayCapture())
+                    {
+                        Log.Warning("Always-On Display Capture could not be started");
+                    }
+                }
+
                 _ = GameDetectionService.StartAsync();
                 GameDetectionService.ForegroundHook.Start();
             }
@@ -739,13 +750,34 @@ namespace Segra.Backend.Recorder
         private static EffectiveRecordingSettings? _activeEffectiveSettings;
         public static EffectiveRecordingSettings? ActiveEffectiveSettings => _activeEffectiveSettings;
 
-        public static bool StartRecording(string name = "Manual Recording", string exePath = "Unknown", bool startManually = false, int? pid = null)
+        public static bool StartAlwaysOnDisplayCapture()
+        {
+            if (!Settings.Instance.AlwaysOnDisplayCapture)
+            {
+                Log.Information("Always-On Display Capture is disabled; skipping start");
+                return false;
+            }
+
+            RecordingMode recordingMode = Settings.Instance.AlwaysOnDisplayCaptureRecordSession
+                ? RecordingMode.Hybrid
+                : RecordingMode.Buffer;
+            Log.Information(
+                "Starting Always-On Display Capture in {RecordingMode} mode",
+                recordingMode);
+
+            return StartRecording(
+                name: "Display Capture",
+                startManually: true,
+                recordingModeOverride: recordingMode);
+        }
+
+        public static bool StartRecording(string name = "Manual Recording", string exePath = "Unknown", bool startManually = false, int? pid = null, RecordingMode? recordingModeOverride = null)
         {
             // Held for the whole call (not just a wait-then-release at entry) so Start and Stop can never interleave.
             _stopRecordingSemaphore.Wait();
             try
             {
-                return StartRecordingCore(name, exePath, startManually, pid);
+                return StartRecordingCore(name, exePath, startManually, pid, recordingModeOverride);
             }
             finally
             {
@@ -753,7 +785,7 @@ namespace Segra.Backend.Recorder
             }
         }
 
-        private static bool StartRecordingCore(string name, string exePath, bool startManually, int? pid)
+        private static bool StartRecordingCore(string name, string exePath, bool startManually, int? pid, RecordingMode? recordingModeOverride)
         {
             if (!IsOBSInstalled())
             {
@@ -771,6 +803,10 @@ namespace Segra.Backend.Recorder
             // Note: the static _activeEffectiveSettings is only published once the early-return guards
             // below have passed, so a blocked start attempt can never clobber an active recording's settings.
             EffectiveRecordingSettings eff = GameSettingsService.Resolve(exePath);
+            if (recordingModeOverride.HasValue)
+            {
+                eff.RecordingMode = recordingModeOverride.Value;
+            }
 
             bool isReplayBufferMode = eff.RecordingMode == RecordingMode.Buffer;
             bool isSessionMode = eff.RecordingMode == RecordingMode.Session;

--- a/Backend/Recorder/OBSService.cs
+++ b/Backend/Recorder/OBSService.cs
@@ -50,6 +50,9 @@ namespace Segra.Backend.Recorder
 
         private static RecordingOutput? _output;
         private static ReplayBuffer? _bufferOutput;
+        private static volatile bool _isBackgroundReplayBufferActive;
+
+        public static bool IsBackgroundReplayBufferActive => _isBackgroundReplayBufferActive;
 
         public static GameCapture? GameCaptureSource { get; set; }
         private static Source? _displaySource;
@@ -619,13 +622,13 @@ namespace Segra.Backend.Recorder
 
                 _ = Task.Run(RecoveryService.CheckForOrphanedFilesAsync);
 
-                // Start this before game detection so a game that is already open cannot replace
-                // the user's requested display capture with a game recording during startup.
-                if (Settings.Instance.AlwaysOnDisplayCapture)
+                // Start before game detection; detection can then suspend this buffer and hand off
+                // cleanly if a game is already running when Segra launches.
+                if (Settings.Instance.BackgroundReplayBuffer)
                 {
-                    if (!StartAlwaysOnDisplayCapture())
+                    if (!StartBackgroundReplayBuffer())
                     {
-                        Log.Warning("Always-On Display Capture could not be started");
+                        Log.Warning("Background replay buffer could not be started");
                     }
                 }
 
@@ -750,25 +753,58 @@ namespace Segra.Backend.Recorder
         private static EffectiveRecordingSettings? _activeEffectiveSettings;
         public static EffectiveRecordingSettings? ActiveEffectiveSettings => _activeEffectiveSettings;
 
-        public static bool StartAlwaysOnDisplayCapture()
+        public static bool StartBackgroundReplayBuffer()
         {
-            if (!Settings.Instance.AlwaysOnDisplayCapture)
+            if (!Settings.Instance.BackgroundReplayBuffer)
             {
-                Log.Information("Always-On Display Capture is disabled; skipping start");
+                Log.Information("Background replay buffer is disabled; skipping start");
                 return false;
             }
 
-            RecordingMode recordingMode = Settings.Instance.AlwaysOnDisplayCaptureRecordSession
-                ? RecordingMode.Hybrid
-                : RecordingMode.Buffer;
-            Log.Information(
-                "Starting Always-On Display Capture in {RecordingMode} mode",
-                recordingMode);
+            Log.Information("Starting background display replay buffer");
+            _isBackgroundReplayBufferActive = true;
+            AppState.Instance.BackgroundReplayBufferActive = true;
 
-            return StartRecording(
-                name: "Display Capture",
-                startManually: true,
-                recordingModeOverride: recordingMode);
+            bool started = false;
+            try
+            {
+                started = StartRecording(
+                    name: "Background Replay Buffer",
+                    startManually: true,
+                    recordingModeOverride: RecordingMode.Buffer);
+                return started;
+            }
+            finally
+            {
+                if (!started)
+                {
+                    _isBackgroundReplayBufferActive = false;
+                    AppState.Instance.BackgroundReplayBufferActive = false;
+                }
+            }
+        }
+
+        public static async Task<bool> StartRecordingReplacingBackgroundBufferAsync(
+            string name = "Manual Recording",
+            string exePath = "Unknown",
+            bool startManually = false,
+            int? pid = null)
+        {
+            bool suspendedBackgroundBuffer = IsBackgroundReplayBufferActive;
+            if (suspendedBackgroundBuffer)
+            {
+                Log.Information("Suspending background replay buffer for a normal recording");
+                await StopRecording(restartBackgroundReplayBuffer: false);
+            }
+
+            bool started = StartRecording(name, exePath, startManually, pid);
+            if (!started && suspendedBackgroundBuffer && Settings.Instance.BackgroundReplayBuffer)
+            {
+                Log.Information("Normal recording did not start; restoring background replay buffer");
+                StartBackgroundReplayBuffer();
+            }
+
+            return started;
         }
 
         public static bool StartRecording(string name = "Manual Recording", string exePath = "Unknown", bool startManually = false, int? pid = null, RecordingMode? recordingModeOverride = null)
@@ -1664,12 +1700,30 @@ namespace Segra.Backend.Recorder
             }
         }
 
-        public static async Task StopRecording()
+        public static Task StopRecording() => StopRecording(restartBackgroundReplayBuffer: true);
+
+        public static async Task StopRecording(bool restartBackgroundReplayBuffer)
         {
+            bool shouldRestartBackgroundReplayBuffer = false;
+            Recording? recordingAtRequest = AppState.Instance.Recording;
+            PreRecording? preRecordingAtRequest = AppState.Instance.PreRecording;
+
             // Prevent race conditions when multiple callers try to stop recording simultaneously
             await _stopRecordingSemaphore.WaitAsync();
             try
             {
+                // A queued duplicate stop must not stop the background buffer (or another recording)
+                // that may have started after the original recording finished.
+                bool recordingChanged = recordingAtRequest != null &&
+                    !ReferenceEquals(recordingAtRequest, AppState.Instance.Recording);
+                bool preRecordingChanged = recordingAtRequest == null && preRecordingAtRequest != null &&
+                    !ReferenceEquals(preRecordingAtRequest, AppState.Instance.PreRecording);
+                if (recordingChanged || preRecordingChanged)
+                {
+                    Log.Information("Ignoring stale StopRecording request because the active recording changed.");
+                    return;
+                }
+
                 // Check if already stopping or stopped
                 if (_isStoppingOrStopped)
                 {
@@ -1679,6 +1733,12 @@ namespace Segra.Backend.Recorder
 
                 // Mark as stopping to prevent concurrent stop attempts
                 _isStoppingOrStopped = true;
+
+                bool wasBackgroundReplayBuffer = IsBackgroundReplayBufferActive;
+                _isBackgroundReplayBufferActive = false;
+                AppState.Instance.BackgroundReplayBufferActive = false;
+                shouldRestartBackgroundReplayBuffer = restartBackgroundReplayBuffer &&
+                    !wasBackgroundReplayBuffer && Settings.Instance.BackgroundReplayBuffer;
 
                 GeneralUtils.SetProcessPriority(ProcessPriorityClass.Normal);
 
@@ -1944,6 +2004,15 @@ namespace Segra.Backend.Recorder
             finally
             {
                 _stopRecordingSemaphore.Release();
+
+                if (shouldRestartBackgroundReplayBuffer && IsInitialized && Settings.Instance.BackgroundReplayBuffer)
+                {
+                    Log.Information("Normal recording ended; restarting background replay buffer");
+                    if (!StartBackgroundReplayBuffer())
+                    {
+                        Log.Warning("Background replay buffer could not be restarted");
+                    }
+                }
             }
         }
 

--- a/Backend/Windows/Input/KeybindCaptureService.cs
+++ b/Backend/Windows/Input/KeybindCaptureService.cs
@@ -189,7 +189,7 @@ namespace Segra.Backend.Windows.Input
                     break;
 
                 case KeybindAction.ToggleRecording:
-                    if (recording != null || preRecording != null)
+                    if ((recording != null && !OBSService.IsBackgroundReplayBufferActive) || preRecording != null)
                     {
                         Log.Information("Hotkey: stopping recording");
                         Task.Run(OBSService.StopRecording);
@@ -197,7 +197,7 @@ namespace Segra.Backend.Windows.Input
                     else
                     {
                         Log.Information("Hotkey: starting display recording");
-                        Task.Run(() => OBSService.StartRecording(startManually: true));
+                        Task.Run(() => OBSService.StartRecordingReplacingBackgroundBufferAsync(startManually: true));
                     }
                     break;
 

--- a/Frontend/src/Components/Settings/CaptureModeSection.tsx
+++ b/Frontend/src/Components/Settings/CaptureModeSection.tsx
@@ -6,10 +6,8 @@ interface CaptureModeSectionProps {
   updateSettings: (updates: Partial<SettingsType>) => void;
 }
 
-type CaptureModeOption = RecordingMode | 'DisplayBuffer';
-
 const captureModes: Array<{
-  id: CaptureModeOption;
+  id: RecordingMode;
   title: string;
   description: string;
   features: string[];
@@ -50,39 +48,16 @@ const captureModes: Array<{
       'No bookmarks',
     ],
   },
-  {
-    id: 'DisplayBuffer',
-    title: 'Always-On Display Buffer',
-    description:
-      'Start a display replay buffer when Segra launches and keep it active when games are detected.',
-    features: [
-      'Starts when Segra launches',
-      'Captures the selected display',
-      'Does not switch to game capture',
-      'No bookmarks',
-    ],
-  },
 ];
 
 export default function CaptureModeSection({ settings, updateSettings }: CaptureModeSectionProps) {
   const appState = useAppState();
-  const isRecording = appState.recording != null || appState.preRecording != null;
-  const selectedMode: CaptureModeOption = settings.alwaysOnDisplayCapture
-    ? 'DisplayBuffer'
-    : settings.recordingMode;
+  const isRecording =
+    !appState.backgroundReplayBufferActive &&
+    (appState.recording != null || appState.preRecording != null);
 
-  const selectMode = (mode: CaptureModeOption) => {
-    if (isRecording) return;
-
-    if (mode === 'DisplayBuffer') {
-      updateSettings({ alwaysOnDisplayCapture: true });
-      return;
-    }
-
-    updateSettings({
-      alwaysOnDisplayCapture: false,
-      recordingMode: mode,
-    });
+  const selectMode = (mode: RecordingMode) => {
+    if (!isRecording) updateSettings({ recordingMode: mode });
   };
 
   return (
@@ -94,7 +69,7 @@ export default function CaptureModeSection({ settings, updateSettings }: Capture
 
       <div className="grid grid-cols-2 gap-6">
         {captureModes.map((mode) => {
-          const isSelected = selectedMode === mode.id;
+          const isSelected = settings.recordingMode === mode.id;
 
           return (
             <button
@@ -104,8 +79,8 @@ export default function CaptureModeSection({ settings, updateSettings }: Capture
               aria-pressed={isSelected}
               onClick={() => selectMode(mode.id)}
               className={`flex min-h-52 w-full flex-col rounded-lg border bg-base-200 p-4 text-left transition-all ${
-                isSelected ? 'border-primary' : 'border-base-400'
-              } ${
+                mode.id === 'Hybrid' ? 'col-span-2' : ''
+              } ${isSelected ? 'border-primary' : 'border-base-400'} ${
                 isRecording ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:bg-base-300'
               }`}
             >
@@ -121,33 +96,22 @@ export default function CaptureModeSection({ settings, updateSettings }: Capture
         })}
       </div>
 
-      {selectedMode === 'DisplayBuffer' && (
-        <div className="mt-4 rounded-lg border border-base-400 bg-base-200 p-4">
-          <label
-            className={`flex items-start gap-3 ${
-              isRecording ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
-            }`}
-          >
-            <input
-              type="checkbox"
-              name="alwaysOnDisplayCaptureRecordSession"
-              checked={settings.alwaysOnDisplayCaptureRecordSession}
-              disabled={isRecording}
-              onChange={(event) =>
-                updateSettings({ alwaysOnDisplayCaptureRecordSession: event.target.checked })
-              }
-              className="checkbox checkbox-primary checkbox-sm mt-0.5"
-            />
-            <span className="flex flex-col">
-              <span className="font-semibold">Also Record Full Display Sessions</span>
-              <span className="mt-1 text-sm text-base-content text-opacity-70">
-                Replay Buffer is always active in this mode. Enable this to also save a continuous
-                full-session recording of your display.
-              </span>
-            </span>
-          </label>
-        </div>
-      )}
+      <label className="mt-6 flex cursor-pointer items-start gap-3 rounded-lg border border-base-400 bg-base-200 p-4">
+        <input
+          type="checkbox"
+          name="backgroundReplayBuffer"
+          checked={settings.backgroundReplayBuffer}
+          onChange={(event) => updateSettings({ backgroundReplayBuffer: event.target.checked })}
+          className="checkbox checkbox-primary checkbox-sm mt-0.5"
+        />
+        <span className="flex flex-col">
+          <span className="font-semibold">Background Replay Buffer</span>
+          <span className="mt-1 text-sm text-base-content text-opacity-70">
+            Keep a display replay buffer ready while Segra is idle. It pauses for normal recordings
+            and starts again when they finish. Only replays you save are written to disk.
+          </span>
+        </span>
+      </label>
     </div>
   );
 }

--- a/Frontend/src/Components/Settings/CaptureModeSection.tsx
+++ b/Frontend/src/Components/Settings/CaptureModeSection.tsx
@@ -1,4 +1,4 @@
-import { Settings as SettingsType } from '../../Models/types';
+import { RecordingMode, Settings as SettingsType } from '../../Models/types';
 import { useAppState } from '../../Context/AppStateContext';
 
 interface CaptureModeSectionProps {
@@ -6,80 +6,148 @@ interface CaptureModeSectionProps {
   updateSettings: (updates: Partial<SettingsType>) => void;
 }
 
+type CaptureModeOption = RecordingMode | 'DisplayBuffer';
+
+const captureModes: Array<{
+  id: CaptureModeOption;
+  title: string;
+  description: string;
+  features: string[];
+}> = [
+  {
+    id: 'Hybrid',
+    title: 'Hybrid (Session + Buffer)',
+    description:
+      'Record the full game session while keeping a replay buffer for saving short highlights.',
+    features: [
+      'Clip without ending the session recording',
+      'Full game integration features',
+      'Access to AI-generated highlights',
+      'Access to Bookmarks',
+    ],
+  },
+  {
+    id: 'Session',
+    title: 'Session Recording',
+    description:
+      'Record an entire detected game session from start to finish for complete gameplay recordings.',
+    features: [
+      'Full session recording',
+      'Full game integration features',
+      'Access to AI-generated highlights',
+      'Access to Bookmarks',
+    ],
+  },
+  {
+    id: 'Buffer',
+    title: 'Game Replay Buffer',
+    description:
+      'Run a replay buffer while a game is detected and save your best moments with a hotkey.',
+    features: [
+      'Efficient storage usage',
+      'Captures detected games',
+      'No full session recording',
+      'No bookmarks',
+    ],
+  },
+  {
+    id: 'DisplayBuffer',
+    title: 'Always-On Display Buffer',
+    description:
+      'Start a display replay buffer when Segra launches and keep it active when games are detected.',
+    features: [
+      'Starts when Segra launches',
+      'Captures the selected display',
+      'Does not switch to game capture',
+      'No bookmarks',
+    ],
+  },
+];
+
 export default function CaptureModeSection({ settings, updateSettings }: CaptureModeSectionProps) {
   const appState = useAppState();
   const isRecording = appState.recording != null || appState.preRecording != null;
+  const selectedMode: CaptureModeOption = settings.alwaysOnDisplayCapture
+    ? 'DisplayBuffer'
+    : settings.recordingMode;
+
+  const selectMode = (mode: CaptureModeOption) => {
+    if (isRecording) return;
+
+    if (mode === 'DisplayBuffer') {
+      updateSettings({ alwaysOnDisplayCapture: true });
+      return;
+    }
+
+    updateSettings({
+      alwaysOnDisplayCapture: false,
+      recordingMode: mode,
+    });
+  };
 
   return (
-    <div className="p-4 bg-base-300 rounded-lg shadow-md border border-custom">
-      <div className="flex items-center gap-2 mb-4">
+    <div className="rounded-lg border border-custom bg-base-300 p-4 shadow-md">
+      <div className="mb-4 flex items-center gap-2">
         <h2 className="text-xl font-semibold">Capture Mode</h2>
         {isRecording && <span className="text-xs text-warning">(locked while recording)</span>}
       </div>
-      <div className="mb-6">
-        <div
-          className={`bg-base-200 p-4 rounded-lg flex flex-col transition-all transition-200 border ${settings.recordingMode == 'Hybrid' ? 'border-primary' : 'border-base-400'} ${isRecording ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:bg-base-300'}`}
-          onClick={() => !isRecording && updateSettings({ recordingMode: 'Hybrid' })}
-        >
-          <div className="flex items-center gap-2 mb-3">
-            <div className="text-lg font-semibold">Hybrid (Session + Buffer)</div>
-          </div>
-          <div className="text-sm text-left text-base-content">
-            <p className="mb-2">
-              Record the full session while keeping a replay buffer. Save short highlights with a
-              hotkey without stopping the session.
-            </p>
-            <div className="text-xs text-base-content text-opacity-70">
-              • Clip without ending the session recording
-              <br />• Full game integration features
-              <br />• Access to AI-generated highlights
-              <br />• Access to Bookmarks
-            </div>
-          </div>
-        </div>
-      </div>
+
       <div className="grid grid-cols-2 gap-6">
-        <div
-          className={`bg-base-200 p-4 rounded-lg flex flex-col transition-all transition-200 border ${settings.recordingMode == 'Session' ? 'border-primary' : 'border-base-400'} ${isRecording ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:bg-base-300'}`}
-          onClick={() => !isRecording && updateSettings({ recordingMode: 'Session' })}
-        >
-          <div className="text-lg font-semibold mb-3">Session Recording</div>
-          <div className="text-sm text-left text-base-content">
-            <p className="mb-2">
-              Records your entire gaming session from start to finish. Ideal for content creators
-              who want complete gameplay recordings.
-            </p>
-            <div className="text-xs text-base-content text-opacity-70">
-              • Uses more storage space
-              <br />
-              • Full game integration features
-              <br />
-              • Access to AI-generated highlights
-              <br />• Access to Bookmarks
-            </div>
-          </div>
-        </div>
-        <div
-          className={`bg-base-200 p-4 rounded-lg flex flex-col transition-all transition-200 border ${settings.recordingMode == 'Buffer' ? 'border-primary' : 'border-base-400'} ${isRecording ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:bg-base-300'}`}
-          onClick={() => !isRecording && updateSettings({ recordingMode: 'Buffer' })}
-        >
-          <div className="flex items-center gap-2 mb-3">
-            <div className="text-lg font-semibold text-center">Replay Buffer</div>
-          </div>
-          <div className="text-sm text-left text-base-content">
-            <p className="mb-2">
-              Continuously records in the background. Save only your best moments with a hotkey
-              press.
-            </p>
-            <div className="text-xs text-base-content text-opacity-70">
-              • Efficient storage usage
-              <br />
-              • No game integration
-              <br />• No bookmarks
-            </div>
-          </div>
-        </div>
+        {captureModes.map((mode) => {
+          const isSelected = selectedMode === mode.id;
+
+          return (
+            <button
+              key={mode.id}
+              type="button"
+              disabled={isRecording}
+              aria-pressed={isSelected}
+              onClick={() => selectMode(mode.id)}
+              className={`flex min-h-52 w-full flex-col rounded-lg border bg-base-200 p-4 text-left transition-all ${
+                isSelected ? 'border-primary' : 'border-base-400'
+              } ${
+                isRecording ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:bg-base-300'
+              }`}
+            >
+              <span className="mb-3 text-lg font-semibold">{mode.title}</span>
+              <span className="mb-2 text-sm text-base-content">{mode.description}</span>
+              <ul className="mt-auto text-xs text-base-content text-opacity-70">
+                {mode.features.map((feature) => (
+                  <li key={feature}>• {feature}</li>
+                ))}
+              </ul>
+            </button>
+          );
+        })}
       </div>
+
+      {selectedMode === 'DisplayBuffer' && (
+        <div className="mt-4 rounded-lg border border-base-400 bg-base-200 p-4">
+          <label
+            className={`flex items-start gap-3 ${
+              isRecording ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
+            }`}
+          >
+            <input
+              type="checkbox"
+              name="alwaysOnDisplayCaptureRecordSession"
+              checked={settings.alwaysOnDisplayCaptureRecordSession}
+              disabled={isRecording}
+              onChange={(event) =>
+                updateSettings({ alwaysOnDisplayCaptureRecordSession: event.target.checked })
+              }
+              className="checkbox checkbox-primary checkbox-sm mt-0.5"
+            />
+            <span className="flex flex-col">
+              <span className="font-semibold">Also Record Full Display Sessions</span>
+              <span className="mt-1 text-sm text-base-content text-opacity-70">
+                Replay Buffer is always active in this mode. Enable this to also save a continuous
+                full-session recording of your display.
+              </span>
+            </span>
+          </label>
+        </div>
+      )}
     </div>
   );
 }

--- a/Frontend/src/Models/types.ts
+++ b/Frontend/src/Models/types.ts
@@ -291,6 +291,8 @@ export interface Settings {
   enableAi: boolean;
   autoGenerateHighlights: boolean;
   runOnStartup: boolean;
+  alwaysOnDisplayCapture: boolean;
+  alwaysOnDisplayCaptureRecordSession: boolean;
   startupWindowMode: StartupWindowMode; // Window state when launched from startup
   closeButtonAction: CloseButtonAction;
   receiveBetaUpdates: boolean;
@@ -374,6 +376,8 @@ export const initialSettings: Settings = {
   enableAi: true,
   autoGenerateHighlights: true,
   runOnStartup: false,
+  alwaysOnDisplayCapture: false,
+  alwaysOnDisplayCaptureRecordSession: false,
   startupWindowMode: 'Minimized',
   closeButtonAction: 'Minimize',
   receiveBetaUpdates: false,

--- a/Frontend/src/Models/types.ts
+++ b/Frontend/src/Models/types.ts
@@ -36,6 +36,7 @@ export interface State {
   gpuVendor: GpuVendor;
   preRecording?: PreRecording;
   recording?: Recording;
+  backgroundReplayBufferActive: boolean;
   hasLoadedObs: boolean;
   content: Content[];
   inputDevices: AudioDevice[];
@@ -291,8 +292,7 @@ export interface Settings {
   enableAi: boolean;
   autoGenerateHighlights: boolean;
   runOnStartup: boolean;
-  alwaysOnDisplayCapture: boolean;
-  alwaysOnDisplayCaptureRecordSession: boolean;
+  backgroundReplayBuffer: boolean;
   startupWindowMode: StartupWindowMode; // Window state when launched from startup
   closeButtonAction: CloseButtonAction;
   receiveBetaUpdates: boolean;
@@ -334,6 +334,7 @@ export interface Settings {
 export const initialState: State = {
   gpuVendor: GpuVendor.Unknown,
   recording: undefined,
+  backgroundReplayBufferActive: false,
   hasLoadedObs: false,
   content: [],
   inputDevices: [],
@@ -376,8 +377,7 @@ export const initialSettings: Settings = {
   enableAi: true,
   autoGenerateHighlights: true,
   runOnStartup: false,
-  alwaysOnDisplayCapture: false,
-  alwaysOnDisplayCaptureRecordSession: false,
+  backgroundReplayBuffer: false,
   startupWindowMode: 'Minimized',
   closeButtonAction: 'Minimize',
   receiveBetaUpdates: false,

--- a/Frontend/src/menu.tsx
+++ b/Frontend/src/menu.tsx
@@ -48,7 +48,9 @@ const MENU_ICONS: Record<MenuItemId, LucideIcon> = {
 export default function Menu({ selectedMenu, onSelectMenu }: MenuProps) {
   const settings = useSettings();
   const appState = useAppState();
-  const { hasLoadedObs, recording, preRecording } = appState;
+  const { hasLoadedObs, recording, preRecording, backgroundReplayBufferActive } = appState;
+  const hasNormalRecording =
+    !backgroundReplayBufferActive && (recording != null || preRecording != null);
   const { updateInfo } = useUpdate();
   const { aiProgress } = useAiHighlights();
   const { obsDownloadProgress } = useObsDownload();
@@ -304,17 +306,15 @@ export default function Menu({ selectedMenu, onSelectMenu }: MenuProps) {
             disabled={
               buttonCooldown ||
               !appState.hasLoadedObs ||
-              (appState.recording && recording && recording.endTime !== null)
+              (hasNormalRecording && recording && recording.endTime !== null)
             }
             onClick={() => {
               setButtonCooldown(true);
               setTimeout(() => setButtonCooldown(false), 1000);
-              sendMessageToBackend(
-                appState.recording || appState.preRecording ? 'StopRecording' : 'StartRecording',
-              );
+              sendMessageToBackend(hasNormalRecording ? 'StopRecording' : 'StartRecording');
             }}
           >
-            {appState.recording || appState.preRecording ? (
+            {hasNormalRecording ? (
               <>
                 <OctagonX className="w-4 h-4" />
                 Stop


### PR DESCRIPTION
When Always-On Display Buffer is selected, Segra starts Display Capture with Replay Buffer. Game detection will not be replacing active display capture. Also record full display sessions can be also enabled as a preference when Always on Buffer is selected.