### PR TITLE
fix: drive OBS at the default device sample rate

### DIFF
--- a/Backend/Recorder/OBSService.cs
+++ b/Backend/Recorder/OBSService.cs
@@ -22,6 +22,7 @@ using System.Text.RegularExpressions;
 using static Segra.Backend.App.MessageService;
 using static Segra.Backend.Shared.GeneralUtils;
 #if WINDOWS
+using Segra.Backend.Windows.Audio;
 using Segra.Backend.Windows.Display;
 #endif
 
@@ -555,6 +556,17 @@ namespace Segra.Backend.Recorder
                 string obsDataPath = Environment.GetEnvironmentVariable("SEGRA_OBS_DATA_PATH") ?? "./data/libobs/";
                 Log.Information($"Linux OBS runtime: data='{obsDataPath}', modules='{obsModulePath}'");
 #endif
+                // Match the default render device's mix format so game capture's WASAPI
+                // process loopback needs no engine-side resampling (its resampler audibly
+                // rings/metallics on rate mismatch, e.g. 48k games into a 44.1k project).
+                // OBS's own resampler handles every other source (mics, desktop loopbacks),
+                // so this rate only has to match where the game's audio session actually runs.
+                int audioSampleRate = 48000;
+#if WINDOWS
+                audioSampleRate = AudioDeviceService.GetDefaultOutputSampleRate();
+#endif
+                Log.Information($"OBS audio sample rate: {audioSampleRate} Hz (default render device mix format, 48 kHz fallback)");
+
                 _obsContext = Obs.Initialize(config =>
                 {
                     config
@@ -568,7 +580,7 @@ namespace Segra.Backend.Recorder
                             .Resolution(1920, 1080)
                             .Fps(60))
                         .WithAudio(a => a
-                            .WithSampleRate(44100)
+                            .WithSampleRate((uint)audioSampleRate)
                             .WithSpeakers(SpeakerLayout.Stereo))
                         .WithLogging((level, message) =>
                         {

--- a/Backend/Windows/Audio/AudioDeviceService.cs
+++ b/Backend/Windows/Audio/AudioDeviceService.cs
@@ -10,6 +10,36 @@ namespace Segra.Backend.Windows.Audio
 
         public static List<AudioDevice> GetOutputDevices() => GetDevices(DataFlow.Render, Role.Console);
 
+        /// <summary>
+        /// Returns the sample rate (Hz) of the default render device's mix format, or 48000
+        /// when it cannot be determined or is a rate OBS shouldn't be driven at.
+        /// Games render to the default (Console role) device, and in WASAPI shared mode their
+        /// audio session runs at exactly this mix rate. OBS requests its project rate from
+        /// game capture's process loopback, so matching the mix rate avoids the Windows audio
+        /// engine resampling the game stream — its resampler audibly rings on rate mismatch.
+        /// </summary>
+        public static int GetDefaultOutputSampleRate()
+        {
+            try
+            {
+                using var enumerator = new MMDeviceEnumerator();
+                using var defaultDevice = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
+                using var audioClient = defaultDevice.AudioClient;
+                int sampleRate = audioClient.MixFormat.SampleRate;
+
+                // Only drive OBS at rates it is routinely used with; anything else (e.g. an
+                // exotic 32 kHz endpoint) falls back to 48 kHz, the Windows/industry default.
+                return sampleRate is 44100 or 48000 or 88200 or 96000 or 176400 or 192000
+                    ? sampleRate
+                    : 48000;
+            }
+            catch
+            {
+                // No default device, or COM failure — 48 kHz is the safest fallback.
+                return 48000;
+            }
+        }
+
         private static string GetCleanDeviceName(string friendlyName)
         {
             // If it's Voicemeeter, Elgato, GoXLR or BEACN, return the original name


### PR DESCRIPTION
Game capture's capture_audio (WASAPI process loopback) is requested at the OBS project rate; when that differs from the game's session rate (typically the default render device mix format), the Windows audio engine resamples 48k->44.1k and audibly rings (metallic audio).

Detect the default render device's mix format rate at OBS init and use it as the project rate (48 kHz fallback), so game audio needs no engine-side resampling. Other sources are unaffected: OBS resamples mics and desktop loopbacks with its own high-quality resampler.