### PR TITLE
Distinguish audio input and output tracks

### DIFF
--- a/Backend/Core/Models/Settings.cs
+++ b/Backend/Core/Models/Settings.cs
@@ -1077,6 +1077,9 @@ namespace Segra.Backend.Core.Models
         [JsonPropertyName("audioTrackNames")]
         public List<string>? AudioTrackNames { get; set; }
 
+        [JsonPropertyName("audioTrackTypes")]
+        public List<string>? AudioTrackTypes { get; set; }
+
         public void AddBookmark(Bookmark bookmark)
         {
             lock (_bookmarksLock)
@@ -1164,6 +1167,10 @@ namespace Segra.Backend.Core.Models
         // Subsequent tracks correspond to each configured audio source
         // in the same order they are added (inputs, then outputs), up to 6 total tracks in OBS.
         public List<string>? AudioTrackNames { get; set; }
+
+        // Semantic type for each audio track: "mix", "input", or "output".
+        // Kept parallel to AudioTrackNames so older metadata remains compatible.
+        public List<string>? AudioTrackTypes { get; set; }
 
         public bool IsImported { get; set; } = false;
 

--- a/Backend/Media/ClipService.cs
+++ b/Backend/Media/ClipService.cs
@@ -24,6 +24,7 @@ namespace Segra.Backend.Media
             List<string> tempClipFiles = new List<string>();
             List<Segment> extractedSegments = new List<Segment>();
             List<List<string>?> extractedSegmentTrackNames = new List<List<string>?>();
+            List<List<string>?> extractedSegmentTrackTypes = new List<List<string>?>();
             List<string> outputFilePaths = new List<string>();
             string? concatFilePath = null;
             string? outputFilePath = null;
@@ -64,20 +65,29 @@ namespace Segra.Backend.Media
                 // Read per-segment audio track names and build union layout
                 bool anySegmentHasMutedTracks = segments.Any(s => s.MutedAudioTracks != null && s.MutedAudioTracks.Count > 0);
                 var perSegmentTrackNames = new List<List<string>?>();
+                var perSegmentTrackTypes = new List<List<string>?>();
                 if (Settings.Instance.ClipKeepSeparateAudioTracks || anySegmentHasMutedTracks)
                 {
                     foreach (var seg in segments)
+                    {
                         perSegmentTrackNames.Add(GetSourceAudioTrackNames(seg));
+                        perSegmentTrackTypes.Add(GetSourceAudioTrackTypes(seg));
+                    }
                 }
                 else
                 {
                     perSegmentTrackNames.AddRange(Enumerable.Repeat<List<string>?>(null, segments.Count));
+                    perSegmentTrackTypes.AddRange(Enumerable.Repeat<List<string>?>(null, segments.Count));
                 }
 
                 // Union of all track names across sources -- used to normalise every temp clip to the same stream layout
                 List<string>? unionAudioLayout = Settings.Instance.ClipKeepSeparateAudioTracks
                     ? BuildUnionAudioLayout(perSegmentTrackNames)
                     : null;
+                List<string>? unionAudioTrackTypes = BuildUnionAudioTrackTypes(
+                    unionAudioLayout,
+                    perSegmentTrackNames,
+                    perSegmentTrackTypes);
 
                 double processedDuration = 0;
                 int segmentIndex = 0;
@@ -126,6 +136,7 @@ namespace Segra.Backend.Media
                     tempClipFiles.Add(tempFileName);
                     extractedSegments.Add(segment);
                     extractedSegmentTrackNames.Add(segmentTrackNames);
+                    extractedSegmentTrackTypes.Add(perSegmentTrackTypes[segmentIndex]);
                     segmentIndex++;
                 }
 
@@ -158,7 +169,10 @@ namespace Segra.Backend.Media
                         var segmentAudioTrackNames = Settings.Instance.ClipKeepSeparateAudioTracks
                             ? extractedSegmentTrackNames[i]
                             : null;
-                        string? segmentClipId = await ContentService.CreateMetadataFile(segmentOutputFilePath, Content.ContentType.Clip, segment.Game ?? "Unknown", null, segment.Title, igdbId: segment.IgdbId, audioTrackNames: segmentAudioTrackNames);
+                        var segmentAudioTrackTypes = Settings.Instance.ClipKeepSeparateAudioTracks
+                            ? extractedSegmentTrackTypes[i]
+                            : null;
+                        string? segmentClipId = await ContentService.CreateMetadataFile(segmentOutputFilePath, Content.ContentType.Clip, segment.Game ?? "Unknown", null, segment.Title, igdbId: segment.IgdbId, audioTrackNames: segmentAudioTrackNames, audioTrackTypes: segmentAudioTrackTypes);
                         await ContentService.CreateThumbnail(segmentOutputFilePath, Content.ContentType.Clip, segmentClipId);
                         await ContentService.CreateWaveformFile(segmentOutputFilePath, Content.ContentType.Clip, segmentClipId);
                     }
@@ -238,7 +252,7 @@ namespace Segra.Backend.Media
 
                 if (!createSeparateClips)
                 {
-                    string? clipId = await ContentService.CreateMetadataFile(outputFilePath!, Content.ContentType.Clip, firstSegment?.Game!, null, firstSegment?.Title, igdbId: firstSegment?.IgdbId, audioTrackNames: unionAudioLayout);
+                    string? clipId = await ContentService.CreateMetadataFile(outputFilePath!, Content.ContentType.Clip, firstSegment?.Game!, null, firstSegment?.Title, igdbId: firstSegment?.IgdbId, audioTrackNames: unionAudioLayout, audioTrackTypes: unionAudioTrackTypes);
                     await ContentService.CreateThumbnail(outputFilePath!, Content.ContentType.Clip, clipId);
                     await ContentService.CreateWaveformFile(outputFilePath!, Content.ContentType.Clip, clipId);
                 }
@@ -793,6 +807,33 @@ namespace Segra.Backend.Media
             return union.Count > 1 ? union : null;
         }
 
+        private static List<string>? BuildUnionAudioTrackTypes(List<string>? unionNames, List<List<string>?> sourceNames, List<List<string>?> sourceTypes)
+        {
+            if (unionNames == null) return null;
+
+            var unionTypes = new List<string>(unionNames.Count) { "mix" };
+            foreach (var unionName in unionNames.Skip(1))
+            {
+                string? type = null;
+                for (int sourceIndex = 0; sourceIndex < sourceNames.Count; sourceIndex++)
+                {
+                    int trackIndex = sourceNames[sourceIndex]?.FindIndex(name =>
+                        string.Equals(name, unionName, StringComparison.OrdinalIgnoreCase)) ?? -1;
+                    if (trackIndex >= 0 && sourceTypes[sourceIndex] != null && trackIndex < sourceTypes[sourceIndex]!.Count)
+                    {
+                        type = sourceTypes[sourceIndex]![trackIndex];
+                        break;
+                    }
+                }
+
+                // Legacy recordings do not have type metadata. Avoid showing a misleading icon
+                // on their exported clips when the source type cannot be established.
+                if (type == null) return null;
+                unionTypes.Add(type);
+            }
+            return unionTypes;
+        }
+
         private static List<string>? GetSourceAudioTrackNames(Segment segment)
         {
             try
@@ -812,6 +853,28 @@ namespace Segra.Backend.Media
             catch (Exception ex)
             {
                 Log.Warning($"Failed to read source audio track names: {ex.Message}");
+            }
+
+            return null;
+        }
+
+        private static List<string>? GetSourceAudioTrackTypes(Segment segment)
+        {
+            try
+            {
+                var contentType = Enum.Parse<Content.ContentType>(segment.Type);
+                var source = AppState.Instance.Content.FirstOrDefault(c =>
+                    c.Type == contentType &&
+                    (!string.IsNullOrEmpty(segment.FilePath)
+                        ? string.Equals(PathUtils.Normalize(c.FilePath), PathUtils.Normalize(segment.FilePath), StringComparison.OrdinalIgnoreCase)
+                        : string.Equals(c.FileName, segment.FileName, StringComparison.OrdinalIgnoreCase)));
+
+                if (source?.AudioTrackTypes != null && source.AudioTrackTypes.Count > 1)
+                    return source.AudioTrackTypes;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning($"Failed to read source audio track types: {ex.Message}");
             }
 
             return null;

--- a/Backend/Media/CompressionService.cs
+++ b/Backend/Media/CompressionService.cs
@@ -81,7 +81,7 @@ namespace Segra.Backend.Media
                     ? $"Replaced original with compressed file: {finalPath}"
                     : $"Saved compressed file as: {finalPath}");
 
-                string? compressedId = await ContentService.CreateMetadataFile(finalPath, contentType, game ?? "Unknown", originalContent.Bookmarks, originalContent.Title, originalContent.CreatedAt, originalContent.IgdbId, originalContent.IsImported, audioTrackNames, compressed: true);
+                string? compressedId = await ContentService.CreateMetadataFile(finalPath, contentType, game ?? "Unknown", originalContent.Bookmarks, originalContent.Title, originalContent.CreatedAt, originalContent.IgdbId, originalContent.IsImported, audioTrackNames, originalContent.AudioTrackTypes, compressed: true);
                 await ContentService.CreateThumbnail(finalPath, contentType, compressedId);
                 await ContentService.CreateWaveformFile(finalPath, contentType, compressedId);
 

--- a/Backend/Media/ContentService.cs
+++ b/Backend/Media/ContentService.cs
@@ -20,7 +20,7 @@ namespace Segra.Backend.Media
         /// Writes the metadata file for a video and returns the new content id, or null when it could not be written.
         /// The id is the file name of the metadata, thumbnail and waveform files.
         /// </summary>
-        public static async Task<string?> CreateMetadataFile(string filePath, Content.ContentType type, string game, List<Bookmark>? bookmarks = null, string? title = null, DateTime? createdAt = null, int? igdbId = null, bool isImported = false, List<string>? audioTrackNames = null, bool compressed = false)
+        public static async Task<string?> CreateMetadataFile(string filePath, Content.ContentType type, string game, List<Bookmark>? bookmarks = null, string? title = null, DateTime? createdAt = null, int? igdbId = null, bool isImported = false, List<string>? audioTrackNames = null, List<string>? audioTrackTypes = null, bool compressed = false)
         {
             bookmarks ??= [];
             filePath = PathUtils.Normalize(filePath);
@@ -66,6 +66,7 @@ namespace Segra.Backend.Media
                     CreatedAt = createdAt ?? DateTime.Now,
                     Duration = duration,
                     AudioTrackNames = audioTrackNames,
+                    AudioTrackTypes = audioTrackTypes,
                     IgdbId = igdbId,
                     IsImported = isImported,
                     Compressed = compressed

--- a/Backend/Media/HighlightService.cs
+++ b/Backend/Media/HighlightService.cs
@@ -101,7 +101,7 @@ namespace Segra.Backend.Media
 
                 // Create metadata, thumbnail, and waveform.
                 // Highlights use stream-copy extract+concat, so they preserve the source's audio tracks.
-                string? highlightId = await ContentService.CreateMetadataFile(outputFilePath, Content.ContentType.Highlight, content.Game!, null, content.Title, igdbId: content.IgdbId, audioTrackNames: content.AudioTrackNames);
+                string? highlightId = await ContentService.CreateMetadataFile(outputFilePath, Content.ContentType.Highlight, content.Game!, null, content.Title, igdbId: content.IgdbId, audioTrackNames: content.AudioTrackNames, audioTrackTypes: content.AudioTrackTypes);
 
                 progressCallback?.Invoke(95, "Creating thumbnail...");
                 await ContentService.CreateThumbnail(outputFilePath, Content.ContentType.Highlight, highlightId);

--- a/Backend/Recorder/OBSService.cs
+++ b/Backend/Recorder/OBSService.cs
@@ -123,6 +123,7 @@ namespace Segra.Backend.Recorder
             public required string Game { get; init; }
             public int? IgdbId { get; init; }
             public List<string>? AudioTrackNames { get; init; }
+            public List<string>? AudioTrackTypes { get; init; }
             public string? FailureReason;
             public readonly TaskCompletionSource<string?> Signal = new(TaskCreationOptions.RunContinuationsAsynchronously);
         }
@@ -165,7 +166,8 @@ namespace Segra.Backend.Recorder
                 {
                     Game = AppState.Instance.Recording?.Game ?? "Unknown",
                     IgdbId = !string.IsNullOrEmpty(exePath) ? GameUtils.GetIgdbIdFromExePath(exePath) : null,
-                    AudioTrackNames = AppState.Instance.Recording?.AudioTrackNames
+                    AudioTrackNames = AppState.Instance.Recording?.AudioTrackNames,
+                    AudioTrackTypes = AppState.Instance.Recording?.AudioTrackTypes
                 };
 
                 lock (_replaySaveLock)
@@ -211,7 +213,7 @@ namespace Segra.Backend.Recorder
                 await EnsureFileReady(savedPath);
 
                 // Create metadata for the buffer recording
-                string? bufferId = await ContentService.CreateMetadataFile(savedPath, Content.ContentType.Buffer, request.Game, igdbId: request.IgdbId, audioTrackNames: request.AudioTrackNames);
+                string? bufferId = await ContentService.CreateMetadataFile(savedPath, Content.ContentType.Buffer, request.Game, igdbId: request.IgdbId, audioTrackNames: request.AudioTrackNames, audioTrackTypes: request.AudioTrackTypes);
                 await ContentService.CreateThumbnail(savedPath, Content.ContentType.Buffer, bufferId);
                 await ContentService.CreateWaveformFile(savedPath, Content.ContentType.Buffer, bufferId);
 
@@ -1152,10 +1154,17 @@ namespace Segra.Backend.Recorder
             // Each group shares one isolated track; all voice chat apps form a single "Voice Chat" group.
             // In GameOnly/GameAndDiscord modes, desktop sources are fallback-only (full mix only).
             var trackGroups = new List<List<Source>>();
+            var trackGroupTypes = new List<string>();
             foreach (var micSource in _micSources)
+            {
                 trackGroups.Add([micSource]);
+                trackGroupTypes.Add("input");
+            }
             foreach (var desktopSource in _desktopSources)
+            {
                 trackGroups.Add([desktopSource]);
+                trackGroupTypes.Add("output");
+            }
 
             int voiceChatGroupIndex = -1;
             if (audioOutputMode != AudioOutputMode.All && GameCaptureSource != null)
@@ -1169,9 +1178,14 @@ namespace Segra.Backend.Recorder
 
                 // Remove desktop sources from the list that gets separate tracks
                 trackGroups = [];
+                trackGroupTypes = [];
                 foreach (var micSource in _micSources)
+                {
                     trackGroups.Add([micSource]);
+                    trackGroupTypes.Add("input");
+                }
                 trackGroups.Add([GameCaptureSource]);
+                trackGroupTypes.Add("output");
 
                 // The voice chat group is reserved even when currently empty so apps launched
                 // mid-recording can still join its track (the encoders are fixed once recording starts)
@@ -1179,6 +1193,7 @@ namespace Segra.Backend.Recorder
                 {
                     voiceChatGroupIndex = trackGroups.Count;
                     trackGroups.Add(_voiceChatSources.Select(v => v.Source).ToList());
+                    trackGroupTypes.Add("output");
                 }
             }
 
@@ -1187,21 +1202,27 @@ namespace Segra.Backend.Recorder
             if (Settings.Instance.InputDevices != null)
             {
                 foreach (var device in Settings.Instance.InputDevices.Where(d => !string.IsNullOrEmpty(d.Id)))
+                {
                     audioDeviceNames.Add(device.Name.Replace(" (Default)", "") ?? "Microphone");
+                }
             }
             if (audioOutputMode == AudioOutputMode.All || GameCaptureSource == null)
             {
                 if (Settings.Instance.OutputDevices != null)
                 {
                     foreach (var device in Settings.Instance.OutputDevices.Where(d => !string.IsNullOrEmpty(d.Id)))
+                    {
                         audioDeviceNames.Add(device.Name.Replace(" (Default)", "") ?? "Desktop Audio");
+                    }
                 }
             }
             else
             {
                 audioDeviceNames.Add("Game Audio");
                 if (audioOutputMode == AudioOutputMode.GameAndDiscord)
+                {
                     audioDeviceNames.Add("Voice Chat");
+                }
             }
 
             bool separateTracks = Settings.Instance.EnableSeparateAudioTracks;
@@ -1246,6 +1267,7 @@ namespace Segra.Backend.Recorder
             // clip creation, UI) matches what OBS actually recorded.
             _audioEncoders.Clear();
             var actualAudioTrackNames = new List<string>(trackCount);
+            var actualAudioTrackTypes = new List<string>(trackCount);
             for (int t = 0; t < trackCount; t++)
             {
                 // Track 0 is the full mix, tracks 1+ are individual devices
@@ -1254,6 +1276,9 @@ namespace Segra.Backend.Recorder
                     : (t - 1 < audioDeviceNames.Count ? audioDeviceNames[t - 1] : $"Audio Track {t + 1}");
 
                 actualAudioTrackNames.Add(encoderName);
+                actualAudioTrackTypes.Add(t == 0
+                    ? "mix"
+                    : trackGroupTypes[t - 1]);
                 var audioEncoder = AudioEncoder.CreateAac(encoderName, 128, t);
                 _audioEncoders.Add(audioEncoder);
             }
@@ -1383,7 +1408,8 @@ namespace Segra.Backend.Recorder
                 IsUsingGameHook = IsGameCaptureHooked,
                 ExePath = exePath,
                 CoverImageId = GameUtils.GetCoverImageIdFromExePath(exePath),
-                AudioTrackNames = actualAudioTrackNames
+                AudioTrackNames = actualAudioTrackNames,
+                AudioTrackTypes = actualAudioTrackTypes
             };
             AppState.Instance.PreRecording = null;
             _ = MessageService.SendStateToFrontend("OBS Start recording");
@@ -1761,7 +1787,7 @@ namespace Segra.Backend.Recorder
                             int? igdbId = !string.IsNullOrEmpty(AppState.Instance.Recording.ExePath)
                                 ? GameUtils.GetIgdbIdFromExePath(AppState.Instance.Recording.ExePath)
                                 : null;
-                            string? sessionId = await ContentService.CreateMetadataFile(AppState.Instance.Recording.FilePath!, Content.ContentType.Session, AppState.Instance.Recording.Game, AppState.Instance.Recording.Bookmarks, igdbId: igdbId, audioTrackNames: AppState.Instance.Recording.AudioTrackNames);
+                            string? sessionId = await ContentService.CreateMetadataFile(AppState.Instance.Recording.FilePath!, Content.ContentType.Session, AppState.Instance.Recording.Game, AppState.Instance.Recording.Bookmarks, igdbId: igdbId, audioTrackNames: AppState.Instance.Recording.AudioTrackNames, audioTrackTypes: AppState.Instance.Recording.AudioTrackTypes);
                             await ContentService.CreateThumbnail(AppState.Instance.Recording.FilePath!, Content.ContentType.Session, sessionId);
                             await ContentService.CreateWaveformFile(AppState.Instance.Recording.FilePath!, Content.ContentType.Session, sessionId);
 
@@ -1861,7 +1887,7 @@ namespace Segra.Backend.Recorder
                             int? igdbId = !string.IsNullOrEmpty(AppState.Instance.Recording.ExePath)
                                 ? GameUtils.GetIgdbIdFromExePath(AppState.Instance.Recording.ExePath)
                                 : null;
-                            string? sessionId = await ContentService.CreateMetadataFile(AppState.Instance.Recording.FilePath!, Content.ContentType.Session, AppState.Instance.Recording.Game, AppState.Instance.Recording.Bookmarks, igdbId: igdbId, audioTrackNames: AppState.Instance.Recording.AudioTrackNames);
+                            string? sessionId = await ContentService.CreateMetadataFile(AppState.Instance.Recording.FilePath!, Content.ContentType.Session, AppState.Instance.Recording.Game, AppState.Instance.Recording.Bookmarks, igdbId: igdbId, audioTrackNames: AppState.Instance.Recording.AudioTrackNames, audioTrackTypes: AppState.Instance.Recording.AudioTrackTypes);
                             await ContentService.CreateThumbnail(AppState.Instance.Recording.FilePath!, Content.ContentType.Session, sessionId);
                             await ContentService.CreateWaveformFile(AppState.Instance.Recording.FilePath!, Content.ContentType.Session, sessionId);
                         }

--- a/Frontend/src/Components/AudioTrackIcon.tsx
+++ b/Frontend/src/Components/AudioTrackIcon.tsx
@@ -1,0 +1,13 @@
+import { AudioLines, Headphones, Mic } from 'lucide-react';
+import type { AudioTrackType } from '../Models/types';
+
+interface AudioTrackIconProps {
+  type?: AudioTrackType;
+  className?: string;
+}
+
+export default function AudioTrackIcon({ type, className = 'h-3.5 w-3.5' }: AudioTrackIconProps) {
+  if (type === 'input') return <Mic className={className} aria-hidden="true" />;
+  if (type === 'output') return <Headphones className={className} aria-hidden="true" />;
+  return <AudioLines className={className} aria-hidden="true" />;
+}

--- a/Frontend/src/Components/SegmentCard.tsx
+++ b/Frontend/src/Components/SegmentCard.tsx
@@ -3,6 +3,7 @@ import { SegmentCardProps } from '../Models/types';
 import { useDrag, useDrop } from 'react-dnd';
 import { Headphones } from 'lucide-react';
 import { useDeleteConfirmation } from '../Hooks/useDeleteConfirmation';
+import AudioTrackIcon from './AudioTrackIcon';
 
 const DRAG_TYPE = 'SEGMENT_CARD';
 
@@ -16,6 +17,7 @@ const SegmentCard: React.FC<SegmentCardProps> = React.memo(
     setHoveredSegmentId,
     removeSegment,
     audioTrackNames,
+    audioTrackTypes,
     onMutedAudioTracksChange,
     onAudioTrackVolumesChange,
   }) => {
@@ -225,6 +227,10 @@ const SegmentCard: React.FC<SegmentCardProps> = React.memo(
                           checked={!isMuted}
                           onChange={() => toggleTrack(i)}
                           className="checkbox checkbox-primary checkbox-xs shrink-0"
+                        />
+                        <AudioTrackIcon
+                          type={audioTrackTypes?.[i]}
+                          className="h-3.5 w-3.5 shrink-0 text-white/60"
                         />
                         <span className="text-xs text-white/80 truncate">
                           {name.replace(' (Default)', '')}

--- a/Frontend/src/Models/types.ts
+++ b/Frontend/src/Models/types.ts
@@ -5,6 +5,7 @@ export type RecordingMode = 'Session' | 'Buffer' | 'Hybrid';
 export type DisplayCaptureMethod = 'Auto' | 'DXGI' | 'WGC';
 
 export type AudioOutputMode = 'All' | 'GameOnly' | 'GameAndDiscord';
+export type AudioTrackType = 'mix' | 'input' | 'output';
 
 export type StartupWindowMode = 'Normal' | 'Minimized';
 export type CloseButtonAction = 'Minimize' | 'Exit';
@@ -26,6 +27,7 @@ export interface Content {
   isImported: boolean;
   compressed: boolean;
   audioTrackNames?: string[];
+  audioTrackTypes?: AudioTrackType[];
 }
 
 export interface OBSVersion {
@@ -454,6 +456,7 @@ export interface SegmentCardProps {
   setHoveredSegmentId: (id: number | null) => void;
   removeSegment: (id: number) => void;
   audioTrackNames?: string[];
+  audioTrackTypes?: AudioTrackType[];
   onMutedAudioTracksChange?: (id: number, mutedTracks: number[]) => void;
   onAudioTrackVolumesChange?: (id: number, volumes: Record<number, number>) => void;
 }

--- a/Frontend/src/Pages/video.tsx
+++ b/Frontend/src/Pages/video.tsx
@@ -47,6 +47,7 @@ import { useAudioTracks } from '../Hooks/useAudioTracks';
 import { AnimatePresence, motion } from 'framer-motion';
 import Button from '../Components/Button';
 import { useDeleteConfirmation } from '../Hooks/useDeleteConfirmation';
+import AudioTrackIcon from '../Components/AudioTrackIcon';
 
 const Crosshair2Dot = React.forwardRef<SVGSVGElement, React.ComponentProps<typeof Icon>>(
   (props, ref) => <Icon {...props} ref={ref} iconNode={crosshair2Dot} />,
@@ -1828,6 +1829,10 @@ export default function VideoComponent({ video }: { video: Content }) {
                                   onChange={() => audioTracks.toggleTrackMute(track.index)}
                                   className="checkbox checkbox-primary checkbox-xs shrink-0"
                                 />
+                                <AudioTrackIcon
+                                  type={video.audioTrackTypes?.[track.index]}
+                                  className="h-3.5 w-3.5 shrink-0 text-white/60"
+                                />
                                 <span className="text-xs text-white/80 truncate select-none">
                                   {track.name.replace(' (Default)', '')}
                                 </span>
@@ -2198,6 +2203,10 @@ export default function VideoComponent({ video }: { video: Content }) {
                             }}
                             className="checkbox checkbox-primary checkbox-xs shrink-0"
                           />
+                          <AudioTrackIcon
+                            type={video.audioTrackTypes?.[i]}
+                            className="h-3.5 w-3.5 shrink-0 text-white/60"
+                          />
                           <span className="text-xs text-white/80 truncate">
                             {name.replace(' (Default)', '')}
                           </span>
@@ -2414,6 +2423,7 @@ export default function VideoComponent({ video }: { video: Content }) {
                   setHoveredSegmentId={setHoveredSegmentId}
                   removeSegment={removeSegment}
                   audioTrackNames={video.audioTrackNames}
+                  audioTrackTypes={video.audioTrackTypes}
                   onMutedAudioTracksChange={(id, mutedTracks) =>
                     updateSegment({
                       ...segments.find((s) => s.id === id)!,


### PR DESCRIPTION
- record whether each separate audio track is a full mix, input device, or output device
- show microphone, headphones, and full-mix icons in player, timeline, and segment audio menus
- preserve track-type metadata through replay saves, clips, highlights, and compression
- keep legacy recordings compatible with a neutral icon when their device type is unknown