### PR TITLE
Graceful handling for storage errors

### DIFF
--- a/Backend/App/MessageService.cs
+++ b/Backend/App/MessageService.cs
@@ -14,6 +14,7 @@ using System.Net.WebSockets;
 using Segra.Backend.Recorder;
 using Segra.Backend.Core.Models;
 using Segra.Backend.Windows.Storage;
+using System.Collections.Concurrent;
 
 namespace Segra.Backend.App
 {
@@ -21,6 +22,8 @@ namespace Segra.Backend.App
     {
         private static WebSocket? activeWebSocket;
         private static readonly SemaphoreSlim sendLock = new SemaphoreSlim(1, 1);
+        private sealed record PendingModal(string Title, string Description, string Type, string? Subtitle);
+        private static readonly ConcurrentQueue<PendingModal> pendingModals = new();
         private static readonly JsonSerializerOptions jsonOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -245,6 +248,7 @@ namespace Segra.Backend.App
                             });
 
                             await UpdateService.SendCurrentUpdateProgressToFrontend();
+                            await FlushPendingModals();
                             _ = Task.Run(() => UpdateService.GetReleaseNotes());
                             break;
                         case "SetVideoLocation":
@@ -485,6 +489,63 @@ namespace Segra.Backend.App
             }
         }
 
+        public static void QueueModal(string title, string description, string type = "info", string? subtitle = null)
+        {
+            pendingModals.Enqueue(new PendingModal(title, description, type, subtitle));
+        }
+
+        private static async Task FlushPendingModals()
+        {
+            while (pendingModals.TryDequeue(out PendingModal? modal))
+            {
+                await ShowModal(modal.Title, modal.Description, modal.Type, modal.Subtitle);
+            }
+        }
+
+        internal sealed record StorageLocationModalContent(string Description);
+
+        internal static StorageLocationModalContent BuildStorageLocationModal(
+            IEnumerable<StorageService.StorageLocationCheck> checks)
+        {
+            StorageService.StorageLocationCheck[] failures = checks
+                .Where(check => !check.IsAvailable)
+                .ToArray();
+
+            var locations = failures
+                .GroupBy(check => check.Path, StringComparer.OrdinalIgnoreCase)
+                .Select(group =>
+                {
+                    string[] labels = group
+                        .Select(check => check.Label.Replace(" folder", string.Empty, StringComparison.OrdinalIgnoreCase))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                    string label = labels.Length == 1
+                        ? $"{labels[0]} folder"
+                        : $"{labels[0]} and {string.Join(" and ", labels.Skip(1).Select(value => value.ToLowerInvariant()))} folders";
+                    string reason = string.Join(
+                        " ",
+                        group.Select(check => check.Description).Distinct(StringComparer.OrdinalIgnoreCase));
+                    return $"{label}\n{group.Key}\n{reason}";
+                })
+                .ToArray();
+
+            string action = failures.All(check => check.Problem == StorageService.StorageLocationProblem.Unavailable)
+                ? "Reconnect the drive or network share, or choose another folder in Settings."
+                : failures.All(check => check.Problem == StorageService.StorageLocationProblem.InsufficientSpace)
+                    ? "Free up space or choose another folder in Settings."
+                    : failures.All(check => check.Problem == StorageService.StorageLocationProblem.NotWritable)
+                        ? "Check the folder permissions or choose another folder in Settings."
+                        : "Resolve the storage issues or choose another folder in Settings.";
+
+            return new StorageLocationModalContent($"{string.Join("\n\n", locations)}\n\n{action}");
+        }
+
+        private static Task ShowStorageLocationError(StorageService.StorageLocationCheck check)
+        {
+            StorageLocationModalContent modal = BuildStorageLocationModal([check]);
+            return ShowModal("Storage unavailable", modal.Description, "error");
+        }
+
         public static async Task ShowModal(string title, string description, string type = "info", string? subtitle = null)
         {
             if (type != "info" && type != "warning" && type != "error")
@@ -651,6 +712,15 @@ namespace Segra.Backend.App
                 string selectedPath = Shared.PathUtils.Normalize(picked);
                 Log.Information($"Selected Folder: {selectedPath}");
 
+                StorageService.StorageLocationCheck locationCheck = StorageService.CheckStorageLocation(
+                    "Recording folder",
+                    selectedPath,
+                    StorageService.MinimumRecordingFreeSpaceBytes);
+                if (!locationCheck.IsAvailable)
+                {
+                    await ShowStorageLocationError(locationCheck);
+                    return;
+                }
                 // Check if the new folder would exceed storage limit
                 bool shouldProceed = await StorageWarningService.CheckContentFolderChange(selectedPath);
                 if (shouldProceed)
@@ -676,6 +746,15 @@ namespace Segra.Backend.App
                 string selectedPath = Shared.PathUtils.Normalize(picked);
                 string oldCacheFolder = Settings.Instance.CacheFolder;
                 Log.Information($"Selected Cache Folder: {selectedPath}");
+
+                StorageService.StorageLocationCheck locationCheck = StorageService.CheckStorageLocation(
+                    "Cache folder",
+                    selectedPath);
+                if (!locationCheck.IsAvailable)
+                {
+                    await ShowStorageLocationError(locationCheck);
+                    return;
+                }
 
                 Settings.Instance.CacheFolder = selectedPath;
                 SettingsService.SaveSettings();

--- a/Backend/App/Program.cs
+++ b/Backend/App/Program.cs
@@ -138,13 +138,24 @@ namespace Segra.Backend.App
 
             StartNamedPipeServer();
 
-            var logDirectory = Path.GetDirectoryName(LogFilePath);
-            if (logDirectory != null && !Directory.Exists(logDirectory))
+            try
             {
-                Directory.CreateDirectory(logDirectory);
-            }
+                var logDirectory = Path.GetDirectoryName(LogFilePath);
+                if (logDirectory != null && !Directory.Exists(logDirectory))
+                {
+                    Directory.CreateDirectory(logDirectory);
+                }
 
-            ConfigureLogging();
+                ConfigureLogging();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Could not initialize file logging: {ex}");
+                Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .WriteTo.Debug()
+                    .CreateLogger();
+            }
 
             VelopackApp.Build()
                 .OnBeforeUpdateFastCallback((v) =>
@@ -267,10 +278,38 @@ namespace Segra.Backend.App
                     _ = PresetsService.ApplyClipPreset("standard");
                 }
 
-                // Ensure content folder exists
-                if (!Directory.Exists(Settings.Instance.ContentFolder))
+                StorageService.StorageLocationCheck[] storageChecks =
+                [
+                    StorageService.CheckStorageLocation(
+                        "Recording folder",
+                        Settings.Instance.ContentFolder,
+                        StorageService.MinimumRecordingFreeSpaceBytes),
+                    StorageService.CheckStorageLocation("Cache folder", Settings.Instance.CacheFolder),
+                    StorageService.CheckStorageLocation("Temporary folder", Path.GetTempPath()),
+                    StorageService.CheckStorageLocation(
+                        "Application data folder",
+                        Path.GetDirectoryName(LogFilePath) ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData))
+                ];
+
+                StorageService.StorageLocationCheck[] unavailableLocations =
+                    storageChecks.Where(check => !check.IsAvailable).ToArray();
+                foreach (StorageService.StorageLocationCheck check in unavailableLocations)
                 {
-                    Directory.CreateDirectory(Settings.Instance.ContentFolder);
+                    Log.Error(
+                        "Storage location unavailable: {Label} at {Path}. {Description}",
+                        check.Label,
+                        check.Path,
+                        check.Description);
+                }
+
+                if (unavailableLocations.Length > 0)
+                {
+                    MessageService.StorageLocationModalContent modal =
+                        MessageService.BuildStorageLocationModal(unavailableLocations);
+                    MessageService.QueueModal(
+                        "Storage unavailable",
+                        modal.Description,
+                        "error");
                 }
 
                 // Run data migrations

--- a/Backend/Recorder/OBSService.cs
+++ b/Backend/Recorder/OBSService.cs
@@ -785,6 +785,33 @@ namespace Segra.Backend.Recorder
             // checks below intentionally run after this so they estimate using the per-game bitrate.
             _activeEffectiveSettings = eff;
 
+            StorageService.StorageLocationCheck[] unavailableLocations =
+            [
+                StorageService.CheckStorageLocation(
+                    "Recording folder",
+                    Settings.Instance.ContentFolder,
+                    GetRecordingFreeSpaceThresholdBytes()),
+                StorageService.CheckStorageLocation("Cache folder", Settings.Instance.CacheFolder),
+                StorageService.CheckStorageLocation("Temporary folder", Path.GetTempPath())
+            ];
+            unavailableLocations = unavailableLocations.Where(check => !check.IsAvailable).ToArray();
+            if (unavailableLocations.Length > 0)
+            {
+                MessageService.StorageLocationModalContent modal =
+                    MessageService.BuildStorageLocationModal(unavailableLocations);
+                Log.Error(
+                    "Cannot start recording because required storage is unavailable: {Details}",
+                    modal.Description);
+                GameDetectionService.PreventRetryRecording = true;
+                Task.Run(() => ShowModal(
+                    "Storage unavailable",
+                    modal.Description,
+                    "error"));
+                Task.Run(() => PlaySound("error"));
+                AppState.Instance.PreRecording = null;
+                return false;
+            }
+
             // Prevent starting if any of the system, recording or temp drives are almost full
             List<StorageService.FullDrive> fullDrives = StorageService.GetFullDrives();
             if (fullDrives.Count > 0)

--- a/Backend/Windows/Storage/StorageService.cs
+++ b/Backend/Windows/Storage/StorageService.cs
@@ -51,6 +51,148 @@ namespace Segra.Backend.Windows.Storage
         // with the configured bitrate (see OBSService), but never drops below this so OBS can always
         // finalize the file cleanly instead of slamming into a completely full disk.
         public const long MinimumRecordingFreeSpaceBytes = 250L * 1024 * 1024; // 250 MB
+        public const long MinimumOperationalFreeSpaceBytes = 100L * 1024 * 1024; // 100 MB
+
+        public enum StorageLocationProblem
+        {
+            None,
+            InvalidPath,
+            Unavailable,
+            NotWritable,
+            InsufficientSpace
+        }
+
+        public sealed record StorageLocationCheck(
+            string Label,
+            string Path,
+            string? Root,
+            bool IsAvailable,
+            StorageLocationProblem Problem,
+            string Description,
+            long? AvailableFreeBytes = null);
+
+        public static StorageLocationCheck CheckStorageLocation(
+            string label,
+            string path,
+            long minimumFreeBytes = MinimumOperationalFreeSpaceBytes)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return Failure(StorageLocationProblem.InvalidPath, "No folder is configured.");
+            }
+
+            string fullPath;
+            string? root;
+            try
+            {
+                fullPath = Path.GetFullPath(path);
+                root = Path.GetPathRoot(fullPath);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                return Failure(StorageLocationProblem.InvalidPath, $"The configured path is invalid: {ex.Message}");
+            }
+
+            if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
+            {
+                return new StorageLocationCheck(
+                    label,
+                    fullPath,
+                    root,
+                    false,
+                    StorageLocationProblem.Unavailable,
+                    "The drive or network share is not currently available.");
+            }
+
+            long? availableFreeBytes = TryGetAvailableFreeSpace(root);
+            if (availableFreeBytes.HasValue && availableFreeBytes.Value < minimumFreeBytes)
+            {
+                double freeMb = availableFreeBytes.Value / (1024.0 * 1024.0);
+                return new StorageLocationCheck(
+                    label,
+                    fullPath,
+                    root,
+                    false,
+                    StorageLocationProblem.InsufficientSpace,
+                    $"The drive only has {freeMb:F0} MB free.",
+                    availableFreeBytes);
+            }
+
+            string? probePath = null;
+            try
+            {
+                Directory.CreateDirectory(fullPath);
+                probePath = Path.Combine(fullPath, $".segra-write-test-{Guid.NewGuid():N}.tmp");
+                using (var probe = new FileStream(probePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 1, FileOptions.None))
+                {
+                    probe.WriteByte(0);
+                    probe.Flush();
+                }
+
+                File.Delete(probePath);
+                probePath = null;
+
+                return new StorageLocationCheck(
+                    label,
+                    fullPath,
+                    root,
+                    true,
+                    StorageLocationProblem.None,
+                    string.Empty,
+                    availableFreeBytes);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
+            {
+                StorageLocationProblem problem = IsDiskFull(ex)
+                    ? StorageLocationProblem.InsufficientSpace
+                    : ex is UnauthorizedAccessException
+                        ? StorageLocationProblem.NotWritable
+                        : StorageLocationProblem.Unavailable;
+
+                string description = problem switch
+                {
+                    StorageLocationProblem.InsufficientSpace => "The drive is full or does not have enough free space.",
+                    StorageLocationProblem.NotWritable => "Segra does not have permission to write to this folder.",
+                    _ => "The drive or network share became unavailable."
+                };
+
+                Log.Warning(ex, "Storage location check failed for {Label} at {Path}", label, fullPath);
+                return new StorageLocationCheck(label, fullPath, root, false, problem, description, availableFreeBytes);
+            }
+            finally
+            {
+                if (probePath != null)
+                {
+                    try { File.Delete(probePath); }
+                    catch { /* best-effort cleanup of the write probe */ }
+                }
+            }
+
+            StorageLocationCheck Failure(StorageLocationProblem problem, string description) =>
+                new(label, path, null, false, problem, description);
+        }
+
+        public static bool IsDiskFull(Exception exception)
+        {
+            int nativeError = exception.HResult & 0xFFFF;
+            return nativeError is 39 or 112 ||
+                exception.Message.Contains("no space left", StringComparison.OrdinalIgnoreCase) ||
+                exception.Message.Contains("disk full", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static long? TryGetAvailableFreeSpace(string root)
+        {
+            try
+            {
+                var drive = new DriveInfo(root);
+                return drive.IsReady ? drive.AvailableFreeSpace : null;
+            }
+            catch
+            {
+                // Some network providers allow file access but do not expose capacity through DriveInfo.
+                return null;
+            }
+        }
 
         // Returns the free space (in bytes) on the drive holding the content folder,
         // or null if it cannot be determined (so callers can choose not to act on errors).


### PR DESCRIPTION
Prevent Segra from crashing or failing silently when its configured storage locations are unavailable, unwritable, or full.